### PR TITLE
APIGOV-15517: Update delete options and scoped/unscoped info

### DIFF
--- a/content/en/docs/integrate_with_central/cli_central/cli_command_reference.md
+++ b/content/en/docs/integrate_with_central/cli_central/cli_command_reference.md
@@ -12,9 +12,7 @@ This section contains the basic commands for creating, fetching, updating, and d
 
 Resources can be *scoped* or *unscoped*.
 
-The scope of a resource refers to the accessibility of the resource. A scoped resource type will be deleted when its scoped, or related, resource is deleted. For example, an API Service resource is scoped to a corresponding Environment resource. When that Environment is deleted, the scoped API Service resource will be deleted as well.
-
-The accessibility, or availability, of an unscoped resource is independent of the accessibility of other resources, meaning that deleting an unscoped resource only deletes that specific resource. For example, deleting a Webhook, which is an unscoped resource type, only deletes that specific Webhook, and does not delete other resources.
+The scope refers to the lifetime and accessibility of a resource. Unscoped resource are top-level resources which act as groups. Scoped resource are grouped under unscoped resources. For example, an API Service resource is scoped to a corresponding Environment resource. When that Environment is deleted, the scoped API Service resource (as well as any other scoped resource belonging to it) will also be deleted. Versus deleting the API Service resource will only delete that one resource.
 
 If the desired resource type is scoped, you must specify the scope name by providing the `-s, --scope <name>` flag.
 
@@ -214,11 +212,12 @@ The following table describes the usage, options, and arguments for the `delete`
 |`axway central delete [options] [<args...>]`             |                                    |
 |**Options**                                              |                   |
 |`--client-id=<value>`                                    |Override your DevOps account's client ID |
-|`-f,--file=<path>`                                       |Filename to use to create the resource  |
-|`-s,--scope=<name>`                                    |Scope name for scoped resources.|
-|`--wait`                                               |Wait for the resources to be completely deleted          |
+|`-f,--file=<path>`                                       |Filename to use to delete the resource   |
+|`-s,--scope=<name>`                                      |Scope name for scoped resources |
+|`--wait`                                                 |Wait for the resources to be completely deleted          |
+|`-y,--yes`                                               |Automatically reply `yes` to any command prompts         |
 |**Arguments**                                            |                   |
-|`args...`                                                  |Command arguments, run `axway central delete` to see the examples |
+|`args...`                                                |Command arguments, run `axway central delete` to see the examples |
 
 The following examples show how to use the `delete` command:
 

--- a/content/en/docs/integrate_with_central/cli_central/cli_command_reference.md
+++ b/content/en/docs/integrate_with_central/cli_central/cli_command_reference.md
@@ -12,7 +12,7 @@ This section contains the basic commands for creating, fetching, updating, and d
 
 Resources can be *scoped* or *unscoped*.
 
-The scope refers to the lifetime and accessibility of a resource. Unscoped resource are top-level resources which act as groups. Scoped resource are grouped under unscoped resources. For example, an API Service resource is scoped to a corresponding Environment resource. When that Environment is deleted, the scoped API Service resource (as well as any other scoped resource belonging to it) will also be deleted. Versus deleting the API Service resource will only delete that one resource.
+The scope refers to the lifetime and accessibility of a resource. Unscoped resource are top-level resources which act as groups. Scoped resource are grouped under unscoped resources. For example, an API Service resource is scoped to a corresponding Environment resource. When that Environment is deleted, the scoped API Service resource (as well as any other scoped resource belonging to it) will also be deleted. Versus deleting the API Service resource, which will only delete that one resource.
 
 If the desired resource type is scoped, you must specify the scope name by providing the `-s, --scope <name>` flag.
 


### PR DESCRIPTION
Thank you for your contribution to the Amplify-Central repo.

## Describe the changes

- Added `--yes` option to `delete` command.
- Fixed mistake in `delete` command's `--file` description where it wrongly indicated it creates a resource.
- Rewrote scoped/unscoped info.
  * Now better matches "Scoped and unscoped resources" section info shown [here](https://docs.axway.com/bundle/amplify-central/page/docs/integrate_with_central/integrate_with_webhooks/index.html).
  * Was wrongly indicating that webhooks were unscoped. _(They're always scoped.)_

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [x] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._
