### PR TITLE
APIGOV-19827: Remove "service-account" creation support from central

### DIFF
--- a/content/en/docs/connect_manage_environ/connect_aws_gateway/_index.md
+++ b/content/en/docs/connect_manage_environ/connect_aws_gateway/_index.md
@@ -50,10 +50,7 @@ For additional logging information, see <https://docs.aws.amazon.com/apigateway/
 ## Prerequisites
 
 * An Axway Amplify Central subscription in the Amplify platform
-* (Optional) A Platform Service Account. See [Managing service accounts](https://docs.axway.com/bundle/platform-management/page/docs/management_guide/organizations/managing_organizations/index.html#managing-service-accounts).
-
-{{< alert title="Note" color="primary" >}}Although both service account types are currently supported, the Amplify Central Service Account will soon be retired. For this reason, it is recommended that you use the Platform Service Account.{{< /alert >}}
-
+* A Platform Service Account. See [Managing service accounts](https://docs.axway.com/bundle/platform-management/page/docs/management_guide/organizations/managing_organizations/index.html#managing-service-accounts).
 * (Optional) An Amplify Central environment. See [Create an environment](/docs/integrate_with_central/cli_central/cli_environments/)
 * API Key credentials on AWS. Allow for CLI access
 * Amazon CloudWatch Service

--- a/content/en/docs/connect_manage_environ/connect_aws_gateway/cloud-administration-operation.md
+++ b/content/en/docs/connect_manage_environ/connect_aws_gateway/cloud-administration-operation.md
@@ -68,7 +68,7 @@ The AWS service usage cost for the agents is explain below.
 
 ### Minimum requirements
 
-* [Amplify Central Service Account](/docs/integrate_with_central/cli_central/cli_install/#option-2---authenticate-and-authorize-your-service-account)
+* [Amplify Platform Service Account](/docs/integrate_with_central/cli_central/cli_install/#option-2---authenticate-and-authorize-your-service-account)
 * [API Key credentials on AWS](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html). Allowing for CLI access.
 * [Amazon CloudWatch Service](https://aws.amazon.com/cloudwatch/)
 * [Amazon Simple Queue Service](https://aws.amazon.com/sqs/)

--- a/content/en/docs/integrate_with_central/cli_central/cli_command_reference.md
+++ b/content/en/docs/integrate_with_central/cli_central/cli_command_reference.md
@@ -147,7 +147,7 @@ The following table describes the usage, options, and arguments for the `create`
 |`axway central create agent-resources`                 |Create the mandatory information for connecting agents to Amplify environment|
 |**Commands**                                             |          |
 |`environment`                                            |Create an environment with the specified name  |
-|`service-account`                                        |Create a service account |
+|`service-account`                                        |Create a service account.<br/>*(Removed in v2.5.0. Use [axway service-account](https://docs.axway.com/bundle/axwaycli-open-docs/page/docs/authentication/service_accounts/index.html) command instead.)* |
 |`agent-resources`                                        |Create the mandatory information for connecting agents to Amplify environment|
 |**Options**                                              |                   |
 |`--client-id=<value>`                                    |Override your DevOps account's client ID |
@@ -168,9 +168,6 @@ axway central create environment newenv -o yaml
 
 # create multiple resources from file
 axway central create -f ./some/folder/resources.yaml
-
-# create a service account (DOSA)
-axway central create service-account
 
 # create agent resources
 axway central create agent-resources


### PR DESCRIPTION
Thank you for your contribution to the Amplify-Central repo.

## Describe the changes

- Central Service Account deprecated in favor of Platform Service Account.
- Removed support for: `axway central create service-account [options]`
- Now must use: `axway service-account create [options]`

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [x] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._
