### PR TITLE
Fix links on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ This repository contains all files for building and deploying the site. The Mark
 
 ## Contribute
 
-We welcome your contributions! To get started, go to https://axway-open-docs.netlify.com/ and click Documentation in the top menu. Browse the documentation and use the options in the right navigation to edit any page using GitHub or Netlify CMS.
+We welcome your contributions! To get started, go to https://amplify-central.netlify.com/ and click Documentation in the top menu. Browse the documentation and use the options in the right navigation to edit any page using GitHub or Netlify CMS.
 
-Before you start contributing, please read the [contribution guidelines](https://axway-open-docs.netlify.app/docs/contribution_guidelines/).
+Before you start contributing, please read the [contribution guidelines](https://confluence.axway.com/display/RIE/Contribution+guidelines).


### PR DESCRIPTION
Thank you for your contribution to the Amplify-Central repo.

## Describe the changes

Links were pointing to axway-open-docs instead of amplify-central

## Checklist for contributors

Before submitting this PR, please make sure:

* [x] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [x] You have signed the [Axway CLA](https://cla.axway.com/)
* [x] You have verified the technical accuracy of your change
* [x] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [x] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._
