### PR TITLE
Updated the links to the Integration Builder docs; changed AMPLIFY to…

### DIFF
--- a/content/en/docs/Overview/_index.md
+++ b/content/en/docs/Overview/_index.md
@@ -75,7 +75,7 @@ Federated data planes are data planes that are connected to the Amplify platform
 * **[API Gateway](https://docs.axway.com/category/apim)** is a runtime gateway that proxies the REST APIs registered in API Manager and enforces configured policies on client requests and responses.
 * **[Streams](https://docs.axway.com/bundle/streams-open-docs/page/docs/index.html)** is a publish/subscribe messaging service where the senders of messages are decoupled from the receivers of messages.
 * **[API Builder](https://docs.axway.com/bundle/api-builder/page/docs/index.html)** is an integration orchestration layer between existing service providers and the API management system, or governance layer, that allows you to quickly implement integration use cases.
-* **[Integration Builder](https://docs.axway.com/bundle/AMPLIFY_Integration_Builder_allOS_en/page/amplify_integration_builder.html)** is an integration tool that allows you to easily build flows, mappings, and connectors between virtually any endpoint. Robust integrations can be built rapidly by using the prebuilt connectors.
+* **[Integration Builder](https://docs.axway.com/bundle/Amplify_Integration_Builder_allOS_en/page/amplify_integration_builder.html)** is an integration tool that allows you to easily build flows, mappings, and connectors between virtually any endpoint. Robust integrations can be built rapidly by using the prebuilt connectors.
 
 ## Try Amplify Central for free
 

--- a/content/en/docs/manage_marketplace/discover-and-consume-catalog-assets.md
+++ b/content/en/docs/manage_marketplace/discover-and-consume-catalog-assets.md
@@ -117,7 +117,7 @@ Follow these steps to download an asset from the catalog:
 
 ## Promote an API to Integration Builder
 
-If you are leveraging the Amplify iPaaS to create integrations between different applications, you can promote an API from the Unified Catalog to Integration Builder as a custom connector with a click of a button. This saves you the trouble of exporting the swagger file and manually import it in Integration Builder. To lean more, see [Amplify Integration Builder](https://docs.axway.com/bundle/AMPLIFY_Integration_Builder_allOS_en/page/amplify_integration_builder.html).
+If you are leveraging the Amplify iPaaS to create integrations between different applications, you can promote an API from the Unified Catalog to Integration Builder as a custom connector with a click of a button. This saves you the trouble of exporting the swagger file and manually import it in Integration Builder. To lean more, see [Amplify Integration Builder](https://docs.axway.com/bundle/Amplify_Integration_Builder_allOS_en/page/amplify_integration_builder.html).
 
 You can promote an API published in the Unified Catalog to Integration Builder as a custom connector. Before you start, ensure that you have access to Integration Builder, and that have your API secured, as well as a valid subscription. For details, see [Subscribe to an API](#subscribe-to-an-api).
 


### PR DESCRIPTION
… Amplify to adhere to standards

Thank you for your contribution to the Amplify-Central repo.

## Describe the changes

I updated the Integration Builder docs to rename AMPLIFY to Amplify to adhere to Axway standards. This change caused the doc URL to change from AMPLIFY_Integration_Builder to Amplify_Integration Builder. This PR is to update the Integration Builder doc links.

## Checklist for contributors

Before submitting this PR, please make sure:

* [ ] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [ ] You have signed the [Axway CLA](https://cla.axway.com/)
* [ ] You have verified the technical accuracy of your change
* [ ] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [ ] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._
