### PR TITLE
Rename Marketplace branding to appearance and added customizing the help menu

### DIFF
--- a/content/en/docs/manage_marketplace/marketplace_branding.md
+++ b/content/en/docs/manage_marketplace/marketplace_branding.md
@@ -100,7 +100,7 @@ From the *Appearance* page, click **Configure** in the Help Menu section to chan
 1. Click the question mark icon to select an icon from the drop down menu to use for the help item image.
 2. Type a label for the menu item.
 3. Type a link to the menu item.
-4. Use the up and down arrow keys to arrange the menu items.
+4. Click the up or down arrow keys to move the menu item's position.
 5. Click the delete icon to remove a menu item.
 6. Click **Clear all items** to start with a blank configuration. *No Menu Configured* is displayed.
 
@@ -108,7 +108,7 @@ From the *Appearance* page, click **Configure** in the Help Menu section to chan
 
 The following APIs provide the equivalent functionality of what is provided throughout the WebUI to brand your Marketplace.
 
-See [APIs](https://apidocs.axway.com/swagger-ui-NEW/index.html?productname=AmplifyPlatform&productversion=1.0.0&filename=swagger.json&disabletry=true#/).
+See [APIs](https://platform.axway.com/api-docs.html#operation/provider_providerFindGroups).
 
 | Function                    |                  |
 |-----------------------------|------------------|


### PR DESCRIPTION
Thank you for your contribution to the Amplify-Central repo.

## Describe the changes

Changed Marketplace branding to appearance per Platform team and approval by Georgiana for referring to the page in the UI. Left branding as an acceptable term through the content. Added customize the Marketplace help menu. Removed use a custom banner.

## Checklist for contributors

Before submitting this PR, please make sure:

* [ ] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [ ] You have signed the [Axway CLA](https://cla.axway.com/)
* [ ] You have verified the technical accuracy of your change
* [ ] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [ ] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._
