### PR TITLE
RDAPI-27476 Make the build.sh script show error in Netlify dashboard when Hugo build fails

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,6 +25,8 @@
 #   - 
 #
 
+set -e
+
 DEBUG=${DEBUG:-false}
 MODE=dev
 while getopts ":np" opt; do
@@ -170,3 +172,4 @@ function fRunHugo() {
 fCheckoutSubmodule
 fMergeContent
 fRunHugo
+echo "[INFO] Done."


### PR DESCRIPTION
Thank you for your contribution to the Amplify-Central repo.

## Describe the changes

Enter a brief description of your changes here to communicate to the maintainers what you changed and why.

## Checklist for contributors

Before submitting this PR, please make sure:

* [ ] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [ ] You have signed the [Axway CLA](https://cla.axway.com/)
* [ ] You have verified the technical accuracy of your change
* [ ] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [ ] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)

_Put an x in the boxes that apply. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your change._
