### PR TITLE
Comment out prism to make code blocks readable

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -111,7 +111,7 @@ github_branch = ""
 # gcs_engine_id = "011737558837375720776:fsdu1nryfng"
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
-prism_syntax_highlighting = true
+# prism_syntax_highlighting = true
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
Thank you for your contribution to the Amplify-Central repo.

## Describe the changes

Be aware that this disables the copy button in code blocks. This is a temporary fix until the root of the problem is determined and fixed.

## Deploy preview link

Please add the deploy preview link to the **specific page** that you've changed.

## Checklist for contributors

Before submitting this PR:

* Verify that all status checks have passed
* For more information on the Markdown linter rules, see [DavidAnson/markdownlint](https://github.com/DavidAnson/markdownlint)
* For first-time contributors, ensure that you have signed the [Axway CLA](https://cla.axway.com/)
