### PR TITLE
Related topics heading at the bottom of index pages

### DIFF
--- a/content/en/docs/Overview/_index.md
+++ b/content/en/docs/Overview/_index.md
@@ -89,3 +89,7 @@ Federated control ans data planes are the environments that are connected to the
 The list of supported environments is growing. For a full list of supported environments, navigate to our [platform](https:/platform.axway.com/) or software downloads at <https://repository.axway.com>.
 
 More information on the Axway API Gateway Manager solution can be found [here](https://docs.axway.com/category/apim/).
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/best_practices/_index.md
+++ b/content/en/docs/best_practices/_index.md
@@ -6,3 +6,7 @@ date: 2021-12-03
 ---
 
 Helpful information / best practices for successfully using the Amplify platform.
+
+## Related topic
+
+See the following topic for related information.

--- a/content/en/docs/connect_manage_environ/_index.md
+++ b/content/en/docs/connect_manage_environ/_index.md
@@ -63,3 +63,7 @@ Webhook assets are used for enabling subscription flows when a catalog user want
 ### Secrets
 
 Secrets are a special kind of asset used with webhooks for securing subscription flows.
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/connect_manage_environ/connect_api_manager/_index.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/_index.md
@@ -93,3 +93,7 @@ Some of the content in the Connect API Manager documentation is of interest to a
 * [Administer agent security](/docs/connect_manage_environ/connected_agent_common_reference/agent_security/)
 
 * [Administer API Manager network traffic](/docs/connect_manage_environ/connected_agent_common_reference/network_traffic/)
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/connect_manage_environ/connect_aws_gateway/_index.md
+++ b/content/en/docs/connect_manage_environ/connect_aws_gateway/_index.md
@@ -83,3 +83,7 @@ The following is a high-level overview of the required steps to connect an AWS A
 * Deploy the agent in the chosen infrastructure (EC2 / ECS-fargate / Docker only)
 
 You will be guided through this procedure using Axway Central CLI. See [Deploy your agents with Axway CLI](/docs/connect_manage_environ/connect_aws_gateway/deploy-your-agents-with-amplify-cli).
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/connect_manage_environ/connect_azure_gateway/_index.md
+++ b/content/en/docs/connect_manage_environ/connect_azure_gateway/_index.md
@@ -154,3 +154,7 @@ To configure monitoring:
 4. Select the Verbose mode and add all headers you want to track. These headers can belong to any request/response (frontend/backend) or you can choose different headers to log using the advanced options.
 
 Now that Azure is all set, you can [Deploy the agents using Axway Central CLI](/docs/connect_manage_environ/connect_azure_gateway/deploy-your-agents-with-amplify-cli) to discover and monitor Azure APIs.
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/_index.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/_index.md
@@ -13,3 +13,7 @@ Axway agents (v7 / AWS / Azure) are built using the [agent SDK](https://github.c
 * Trace redaction parameters (`TRACEABILITY_REDACTION_*`)
 * Common error codes related to the previous features
 * Securing credentials in agent configuration
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/connect_manage_environ/manage_services/_index.md
+++ b/content/en/docs/connect_manage_environ/manage_services/_index.md
@@ -13,3 +13,7 @@ If you want to automate the service discovery from an existing gateway, there ar
 * [AWS Gateway](/docs/connect_manage_environ/connect_aws_gateway)
 * [Azure Gateway](/docs/connect_manage_environ/connect_azure_gateway)
 * [Istio Gateway](/docs/connect_manage_environ/mesh_management)
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/connect_manage_environ/mesh_management/_index.md
+++ b/content/en/docs/connect_manage_environ/mesh_management/_index.md
@@ -47,3 +47,7 @@ The Amplify Istio Discovery Agent listens for events from Kubernetes to Virtual 
 ### Amplify Istio Traceability Agent
 
 The Amplify Istio Traceability Agent (TA) sends metrics and logs for API activity back to Amplify so that you can monitor service activity and troubleshoot your services. All API transactions are captured and sent to Amplify. The agent has deployment configuration options that control the optional logging of request and response headers. The payload remains in the hybrid data plane and can be operated on by other native tools.
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/get_actionable_insights/_index.md
+++ b/content/en/docs/get_actionable_insights/_index.md
@@ -4,4 +4,8 @@ linkTitle: Get insights into your activity
 weight: 525
 date: 2022-09-15
 ---
-The following topics provide details on obtaining insights into your activity.
+Obtaining insights into your activity.
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/integrate_with_central/_index.md
+++ b/content/en/docs/integrate_with_central/_index.md
@@ -39,3 +39,7 @@ It all depends on what you want to accomplish with the platform:
 * If you want to manipulate Amplify resources, the APIs or [Axway Central CLI](/docs/integrate_with_central/cli_central/cli_command_reference/) can be used to add/update/remove resources.
 
 * If you want to trigger a flow when specific events happen in Amplify, you will need a [webhook integration](/docs/integrate_with_central/webhook/).
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/integrate_with_central/cli_central/_index.md
+++ b/content/en/docs/integrate_with_central/cli_central/_index.md
@@ -153,3 +153,6 @@ To delete a resource that represents an environment type with a name “hellowor
 ```bash
 axway central delete environment helloworld
 ```
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/integrate_with_central/webhook/_index.md
+++ b/content/en/docs/integrate_with_central/webhook/_index.md
@@ -339,4 +339,6 @@ Example of a webhook payload referencing a secret:
 * **$spec.auth.secret.key**: key to the secret, which will be used to invoke the webhook.
 * **$spec.enabled**: when enabled, will invoke the webhook.
 
+## Related topics
+
 The links below provide a step-by-step guide for common integrations through events / webhooks.

--- a/content/en/docs/manage_asset_catalog/_index.md
+++ b/content/en/docs/manage_asset_catalog/_index.md
@@ -24,3 +24,7 @@ The asset model is flexible, so APIs can be group to suit individual needs.
 Once the Asset Catalog has been used to manage and group API services into assets, they are deployed as products in the [Product Foundry](/docs/manage_product_foundry) where they can be attached to subscription plans and consumed from the [Marketplace](/docs/manage_marketplace).
 
 For information on the lifecycle of an asset, see [Asset lifecycle](/docs/manage_asset_catalog/asset_lifecycle/).
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/manage_marketplace/_index.md
+++ b/content/en/docs/manage_marketplace/_index.md
@@ -22,3 +22,7 @@ Consumers can explore the Marketplace to find products that address their needs,
 **Self signup** - Providers can configure whether users can self register with an account in the Marketplace and create their own consumer organization independent of the provider organization.
 
 **Extended product documentation** - Providers can create comprehensive product documentation via markdown format, providing a uniform experience for all Marketplace content.
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/manage_marketplace/billing_integration/_index.md
+++ b/content/en/docs/manage_marketplace/billing_integration/_index.md
@@ -11,3 +11,7 @@ The Billing integration solution consists of [integration flows, connections and
 * An API provider creates a product plan, which automatically triggers a *Provision Plan* integration flow to create a corresponding billing plan.
 * An API consumer subscribes to the product plan and the *Provision Subscription* integration flow links the subscriber to a billing account.
 * All API traffic related to the linked subscription is queried for and reported to the billing platform by the *Traffic Reporter* integration flow.
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/manage_marketplace/consumer_experience/_index.md
+++ b/content/en/docs/manage_marketplace/consumer_experience/_index.md
@@ -19,3 +19,7 @@ There are two ways of signing up in the Marketplace:
 Once consumers are logged in, they can browse products, subscribe to products, request access and credentials for resource they wants to use, and get [insight](/docs/get_actionable_insights/consumer_insights/) into their API consumption.
 
 {{< alert title="Note" color="primary" >}}Because a consumer can belong to multiple organizations, it is preferable to configure the user account to always ask for the organization. Refer to Platform home > Account > Settings > Org login Rule : Always ask for Org option{{< /alert >}}
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/manage_product_foundry/_index.md
+++ b/content/en/docs/manage_product_foundry/_index.md
@@ -32,3 +32,7 @@ A product is a group of linked assets that create a business capability. A produ
     * A plan allows users to define quota for limiting the associated resource consumption.
 
 To make a product available for consumption by subscribers, the product is published into the Marketplace, which is the storefront into all products exposed for discovery and consumption by internal and / or external consumers. For additional information, see [Manage your Marketplace](/docs/manage_marketplace/).
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/manage_service_registry/_index.md
+++ b/content/en/docs/manage_service_registry/_index.md
@@ -10,3 +10,7 @@ The Service Registry allows users to view their API services (auto-discovered an
 ## What is a service
 
 A service is a representation of all items related to an API that belongs to an environment. Services can be auto discovered with agents or manually registered in an environment.  
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/manage_unified_catalog/_index.md
+++ b/content/en/docs/manage_unified_catalog/_index.md
@@ -45,3 +45,7 @@ The Unified Catalog supports the following type of assets:
 * AsyncAPI: Supported as "Unstructured" type to publish the specification of the API.
 * MFT flows: Manage File Transfer Service definitions.
 * Custom: Custom assets, such as API Definitions that are technology agnostic, SDKs, tutorials, etc.
+
+## Related topics
+
+See the following topics for related information.

--- a/content/en/docs/saas_api_gateway/_index.md
+++ b/content/en/docs/saas_api_gateway/_index.md
@@ -14,3 +14,7 @@ Amplify provides the Amplify SaaS API Gateway as a single point of entry for all
 * Publish the API in the Amplify Unified Catalog for consumers to discover
 * Monitor the API traffic usage
 * DevOps integration for configuration and deployment
+
+## Related topics
+
+See the following topics for related information.


### PR DESCRIPTION
Thank you for your contribution to the Amplify-Central repo.

## Describe the changes

The related topics links at the bottom of the index pages displayed with no introduction. A Related topics heading and sentence that explains the links was added. 

Please add the deploy preview link to the **specific page** that you've changed.

## Checklist for contributors

Before submitting this PR:

* Verify that all status checks have passed
* For more information on the Markdown linter rules, see [DavidAnson/markdownlint](https://github.com/DavidAnson/markdownlint)
* For first-time contributors, ensure that you have signed the [Axway CLA](https://cla.axway.com/)
