### PR TITLE
APIGOV-26514 - add github discovery service documentation

### DIFF
--- a/content/en/docs/connect_manage_environ/_index.md
+++ b/content/en/docs/connect_manage_environ/_index.md
@@ -38,6 +38,7 @@ For more information about the agents, see:
 * [Discovery and Traceability Agents for AWS API Gateway](/docs/connect_manage_environ/connect_aws_gateway/).
 * [Discovery and Traceability Agents for Azure API Management Services](/docs/connect_manage_environ/connect_azure_gateway/).
 * [Discovery and Traceability Agents for Istio Gateway](/docs/connect_manage_environ/mesh_management/).
+* [Discovery Agents for GitHub Repository](/docs/connect_manage_environ/connect_github_repository/).
 
 To manually synchronize your environment, you can use the [Axway Central CLI](/docs/integrate_with_central/cli_central/cli_environments) or the [Amplify APIs](https://apicentral.axway.com/apis/docs). Note that changes in your deployment will not be automatically synchronized with Amplify.
 

--- a/content/en/docs/connect_manage_environ/connect_apigee_x/_index.md
+++ b/content/en/docs/connect_manage_environ/connect_apigee_x/_index.md
@@ -59,7 +59,7 @@ The Traceability Agent gathers usage metrics for all proxies defined in Apigee X
 ## Embedded agent configuration pre-requisites
 
 * Any machine (Windows / Linux / Mac) where:
-    * You can access platform.axway.com, login.axway.com and axway.jfrog.io on port 443
+    * You can access platform.axway.com and login.axway.com on port 443
     * You can install and run Axway Central CLI (node.js module)
     * You can access the npm package (for installing Axway CLI)
     * You can install OpenSSL
@@ -133,12 +133,11 @@ axway central install agents
 
 The installation procedure will prompt for the following:
 
-1. Select the type of gateway you want to connect to Apigee-X in this scenario).
-2. Select **Yes** when asked if the agent will be embedded.
-3. Platform connectivity:
+1. Select the type of gateway you want to connect to Apigee-X in this scenario.
+2. Platform connectivity:
    * **Environment**: can be an existing environment or one that will be created by the installation procedure
-   * **Team**: can be an existing team or one that will be created by the installation procedure
-4. Apigee Configuration Setup:
+   * **Team**: select an existing team
+3. Apigee Configuration Setup:
    * **Project ID**: the Project ID for your Google Cloud Platform project
    * **Developer Email**: the email address of a developer, defined in Apigee, that will be given ownership of all Applications
    * **Client Email**: the email address, principal name, for the service account in GCP that has the role to discovery Apigee resources

--- a/content/en/docs/connect_manage_environ/connect_aws_gateway/deploy-embedded-agents.md
+++ b/content/en/docs/connect_manage_environ/connect_aws_gateway/deploy-embedded-agents.md
@@ -25,7 +25,7 @@ Axway Central CLI and Amplify platform connectivity are required to configure th
 ## Embedded agent configuration pre-requisites
 
 * Any machine (Windows / Linux / Mac) where:
-    * You can access platform.axway.com, login.axway.com and axway.jfrog.io on port 443
+    * You can access platform.axway.com and login.axway.com on port 443
     * You can install and run Axway Central CLI (node.js module)
     * You can access the npm package (for installing Axway CLI)
     * You can install OpenSSL
@@ -103,7 +103,7 @@ The installation procedure will prompt for the following:
 2. Select **Yes** when asked if the agent will be embedded.
 3. Platform connectivity:
    * **Environment**: can be an existing environment or one that will be created by the installation procedure
-   * **Team**: can be an existing team or one that will be created by the installation procedure
+   * **Team**: select an existing team
 4. AWS Configuration Setup options:
    * **Region**: the AWS API Gateway resources
    * **Authentication Type**: select either Assume Role Policy or Access and Secret Keys

--- a/content/en/docs/connect_manage_environ/connect_github_repository/_index.md
+++ b/content/en/docs/connect_manage_environ/connect_github_repository/_index.md
@@ -26,7 +26,8 @@ The Discovery Agent is used to discover new specification files within the confi
 
 * Find all files within the paths configured
 * From those files validate that they match at least one of the patterns configured, if no patterns are configured all files are discovered
-* The agent then creates an API service and revision to represent that specification file in Amplify Central.
+* The agent then creates an API service and revision to represent that specification file in Amplify Central
+* If the files is of a known specification type then the service will be marked with that type, otherwise the service will have a type of `Unstructured`
 
 ### Installation via CLI
 

--- a/content/en/docs/connect_manage_environ/connect_github_repository/_index.md
+++ b/content/en/docs/connect_manage_environ/connect_github_repository/_index.md
@@ -34,7 +34,7 @@ The Discovery Agent is used to discover new specification files within the confi
 ## Embedded agent configuration pre-requisites
 
 * Any machine (Windows / Linux / Mac) where:
-    * You can access platform.axway.com, login.axway.com and axway.jfrog.io on port 443
+    * You can access platform.axway.com and login.axway.com on port 443
     * You can install and run Axway Central CLI (node.js module)
     * You can access the npm package (for installing Axway CLI)
     * You can install OpenSSL
@@ -98,7 +98,7 @@ If you are a member of multiple Amplify organizations, you may have to choose an
 
 ### Step 3: Run the agents' configure procedure
 
-The Axway Central CLI will guide you through the configuration of the agents. See [Embedded GitHub agents setup](/docs/connect_manage_environ/connect_apigee_x/embedded-agent-setup/) for the prerequisite setup on GCP and Apigee.
+The Axway Central CLI will guide you through the configuration of the agents. See [Embedded GitHub agents setup](/docs/connect_manage_environ/connect_github_repository/embedded-agent-setup/) for the prerequisite setup on GCP and Apigee.
 
 Run the following command to start the configuration procedure:
 
@@ -108,20 +108,19 @@ axway central install agents
 
 The installation procedure will prompt for the following:
 
-1. Select the type of gateway you want to connect to GitHub in this scenario).
-2. Select **Yes** when asked if the agent will be embedded.
-3. Platform connectivity:
+1. Select the type of gateway you want to connect to GitHub in this scenario.
+2. Platform connectivity:
    * **Environment**: can be an existing environment or one that will be created by the installation procedure
-   * **Team**: can be an existing team or one that will be created by the installation procedure
-4. GitHub Configuration Setup:
+   * **Team**: select an existing team
+3. GitHub Configuration Setup:
    * **Access Token**: the access token the agent will use to read the files in the repository
    * Set how often the Embedded agent should check GitHub for changes, preferred is no frequency and triggered via a CI/CD pipeline. See [Triggering the agent to run discovery](/docs/connect_manage_environ/connected_agent_common_reference/embedded-agent-triggers/#triggering-the-agent-to-run-discovery)
    * Set if the agent should discover GitHub resources after installation is complete
    * **Repository Owner Name**: the name of the owner of the repository
    * **Repository Name**: the name of the repository
-   * **Paths**: the paths that the agent will look for specs in
+   * **Paths**: the paths that the agent will look for specs in, paths should start with a `/` character
    * **Filename Patterns**: the patterns that a filename must match to be discovered
      * The pattens here are regular expressions [RE2 Syntax](https://github.com/google/re2/wiki/Syntax), only one pattern must match to discover a specification file
      * The pattern will pass if it matches any part of the filename, if the desire is to match the whole name then adding anchors to the expression should be used (ex: `^spec\.json$`, this will match only files that literally named `spec.json`)
 
-Once you have answered all questions, the Embedded agent will be created. The process will securely store the authentication data and validate it by connecting to GitHub. If set to discover GitHut resources upon installation, the agent will immediately discover your resources and show them in the Service Registry.
+Once you have answered all questions, the Embedded agent will be created. The process will securely store the authentication data and validate it by connecting to GitHub. If set to discover GitHub resources upon installation, the agent will immediately discover your resources and show them in the Service Registry.

--- a/content/en/docs/connect_manage_environ/connect_github_repository/_index.md
+++ b/content/en/docs/connect_manage_environ/connect_github_repository/_index.md
@@ -1,0 +1,126 @@
+---
+title: Connect GitHub Repository
+linkTitle: Connect GitHub Repository
+weight: 110
+---
+Connect a GitHub Repository and Amplify so you can discover your API specifications within your repository.
+
+## Why do you want to connect GitHub and Amplify?
+
+Connecting a GitHub Repository to Amplify will provide you with a global centralized view of your APIs.
+
+* Detect changes to GitHub specification files using the Discovery Agent. The Discovery Agent pushes the specification file as an API Service for the environment.
+
+## Before you start
+
+* Read [Embedded GitHub agent setup](/docs/connect_manage_environ/connect_github_repository/embedded-agent-setup/)
+* Gather information on GitHub:
+    * The access token that the agent will use to connect to GitHub
+    * The repository owner name that the agent will connect to
+    * The repository name that the agent will connect to
+    * The paths and filname patterns that the agent should discover
+
+### Discovery Agent
+
+The Discovery Agent is used to discover new specification files within the configured paths that also match any of the configured file name patterns.
+
+* Find all files within the paths configured
+* From those files validate that they match at least one of the patterns configured, if no patterns are configured all files are discovered
+* The agent then creates an API service and revision to represent that specification file in Amplify Central.
+
+### Installation via CLI
+
+## Embedded agent configuration pre-requisites
+
+* Any machine (Windows / Linux / Mac) where:
+    * You can access platform.axway.com, login.axway.com and axway.jfrog.io on port 443
+    * You can install and run Axway Central CLI (node.js module)
+    * You can access the npm package (for installing Axway CLI)
+    * You can install OpenSSL
+    * There is a graphical environment (optional)
+
+## Configure the agents with Axway Central CLI
+
+Use Axway Central CLI to install the agents. This CLI will prompt you for answers regarding GitHub access information and where to store the discovered APIs in the Amplify platform.
+
+### Step 1: Install Axway Central CLI
+
+Follow the instructions described in [Install Axway Central CLI](/docs/integrate_with_central/cli_central/cli_install/).
+
+You can validate your installation by running: `axway central --version`.
+
+### Step 2: Identify yourself to Amplify platform with Axway CLI
+
+There are two ways to authenticate with Axway CLI:
+
+* With an administrator username/password via a browser
+* With a platform service account and a username/password via a prompt
+
+#### Default mode with browser authentication
+
+Run the following command to use Central CLI to log in with your Amplify platform credentials:
+
+```shell
+axway auth login
+```
+
+A browser will automatically open.
+Enter your valid credentials (email address and password). Once the *Authorization Successful* message is displayed, go back to Axway CLI.
+
+If you are a member of multiple Amplify organizations, you may have to choose an organization.
+
+#### Headless mode authentication with service account
+
+You must have a platform service account and a regular administrator account for the headless mode. The permissions of the service account will be overridden by the permission of the administrator account.
+
+```shell
+# command syntax: Log into a service account with platform tooling credentials:
+axway auth login --client-id <id> --secret-file <path> --username <email>
+
+# the command will prompt you to enter your username password
+```
+
+Sample:
+
+```shell
+axway auth login --client-id plsa_a1d6e0a8-XXXXX --secret-file /home/user/axway/SAKeysPlatformSA/private_key.pem --username admin@mail.com
+AXWAY CLI, version 3.1.0
+Copyright (c) 2018-2021, Axway, Inc. All Rights Reserved.
+
+√ Password: · **********
+
+You are logged into a platform account in organization Axway (a1d6e0a8-XXXXX) as admin@mail.com.
+The current region is set to US.
+```
+
+If you are a member of multiple Amplify organizations, you may have to choose an organization using the `axway auth switch --org <orgId|orgName>` command.
+
+### Step 3: Run the agents' configure procedure
+
+The Axway Central CLI will guide you through the configuration of the agents. See [Embedded GitHub agents setup](/docs/connect_manage_environ/connect_apigee_x/embedded-agent-setup/) for the prerequisite setup on GCP and Apigee.
+
+Run the following command to start the configuration procedure:
+
+```shell
+axway central install agents
+```
+
+The installation procedure will prompt for the following:
+
+1. Select the type of gateway you want to connect to GitHub in this scenario).
+2. Select **Yes** when asked if the agent will be embedded.
+3. Platform connectivity:
+   * **Environment**: can be an existing environment or one that will be created by the installation procedure
+   * **Team**: can be an existing team or one that will be created by the installation procedure
+4. GitHub Configuration Setup:
+   * **Access Token**: the access token the agent will use to read the files in the repository
+   * Set how often the Embedded agent should check GitHub for changes, preferred is no frequency and triggered via a CI/CD pipeline. See [Triggering the agent to run discovery](/docs/connect_manage_environ/connected_agent_common_reference/embedded-agent-triggers/#triggering-the-agent-to-run-discovery)
+   * Set if the agent should discover GitHub resources after installation is complete
+   * **Repository Owner Name**: the name of the owner of the repository
+   * **Repository Name**: the name of the repository
+   * **Paths**: the paths that the agent will look for specs in
+   * **Filename Patterns**: the patterns that a filename must match to be discovered
+     * The pattens here are regular expressions [RE2 Syntax](https://github.com/google/re2/wiki/Syntax), only one pattern must match to discover a specification file
+     * The pattern will pass if it matches any part of the filename, if the desire is to match the whole name then adding anchors to the expression should be used (ex: `^spec\.json$`, this will match only files that literally named `spec.json`)
+
+Once you have answered all questions, the Embedded agent will be created. The process will securely store the authentication data and validate it by connecting to GitHub. If set to discover GitHut resources upon installation, the agent will immediately discover your resources and show them in the Service Registry.

--- a/content/en/docs/connect_manage_environ/connect_github_repository/_index.md
+++ b/content/en/docs/connect_manage_environ/connect_github_repository/_index.md
@@ -7,9 +7,12 @@ Connect a GitHub Repository and Amplify so you can discover your API specificati
 
 ## Why do you want to connect GitHub and Amplify?
 
-Connecting a GitHub Repository to Amplify will provide you with a global centralized view of your APIs.
+Connecting a GitHub Repository to Amplify will provide you with a global centralized view of your APIs. Once connected, Discovery Agent will detect changes to a GitHub specification file and push the specification file as an API Service for the environment. The Discovery Agent discovers new specification files within the configured paths that match any of the configured file name patterns:
 
-* Detect changes to GitHub specification files using the Discovery Agent. The Discovery Agent pushes the specification file as an API Service for the environment.
+* Finds all files within the paths configured
+* From those files, validates that they match at least one of the patterns configured. If no patterns are configured, then all files are discovered
+* The agent then creates an API service and revision to represent that specification file in Amplify Central
+* If the files are of a known specification type, then the service will be marked with that type. Otherwise, the service will have a type of `Unstructured`
 
 ## Before you start
 
@@ -19,28 +22,14 @@ Connecting a GitHub Repository to Amplify will provide you with a global central
     * The repository owner name that the agent will connect to
     * The repository name that the agent will connect to
     * The paths and filename patterns that the agent should discover
-
-### Discovery Agent
-
-The Discovery Agent is used to discover new specification files within the configured paths that also match any of the configured file name patterns.
-
-* Find all files within the paths configured
-* From those files validate that they match at least one of the patterns configured. If no patterns are configured, then all files are discovered
-* The agent then creates an API service and revision to represent that specification file in Amplify Central
-* If the files are of a known specification type, then the service will be marked with that type. Otherwise, the service will have a type of `Unstructured`
-
-### Installation via CLI
-
-## Embedded agent configuration pre-requisites
-
-* Any machine (Windows / Linux / Mac) where:
+* Ensure your machine (Windows / Linux / Mac) meets the Embedded agent configuration prerequisites, where:
     * You can access platform.axway.com and login.axway.com on port 443
     * You can install and run Axway Central CLI (node.js module)
     * You can access the npm package (for installing Axway CLI)
     * You can install OpenSSL
     * There is a graphical environment (optional)
 
-## Configure the agents with Axway Central CLI
+## Configure the agents with Axway Central CLI and GitHub
 
 Use Axway Central CLI to install the agents. This CLI will prompt you for answers regarding GitHub access information and where to store the discovered APIs in the Amplify platform.
 
@@ -121,6 +110,6 @@ The installation procedure will prompt for the following:
    * **Paths**: the paths that the agent will look for specs in, paths should start with a `/` character
    * **Filename Patterns**: the patterns that a filename must match to be discovered
      * The pattens here are regular expressions [RE2 Syntax](https://github.com/google/re2/wiki/Syntax), only one pattern must match to discover a specification file
-     * The pattern will pass if it matches any part of the filename. To match the whole name, add anchors to the expression (ex: `^spec\.json$`, this will match only files that literally named `spec.json`)
+     * The pattern will pass if it matches any part of the filename. To match the whole name, add anchors to the expression (example: `^spec\.json$`, this will match only files that are literally named `spec.json`)
 
 Once you have answered all questions, the Embedded agent will be created. The process will securely store the authentication data and validate it by connecting to GitHub. If set to discover GitHub resources upon installation, the agent will immediately discover your resources and show them in the Service Registry.

--- a/content/en/docs/connect_manage_environ/connect_github_repository/_index.md
+++ b/content/en/docs/connect_manage_environ/connect_github_repository/_index.md
@@ -18,16 +18,16 @@ Connecting a GitHub Repository to Amplify will provide you with a global central
     * The access token that the agent will use to connect to GitHub
     * The repository owner name that the agent will connect to
     * The repository name that the agent will connect to
-    * The paths and filname patterns that the agent should discover
+    * The paths and filename patterns that the agent should discover
 
 ### Discovery Agent
 
 The Discovery Agent is used to discover new specification files within the configured paths that also match any of the configured file name patterns.
 
 * Find all files within the paths configured
-* From those files validate that they match at least one of the patterns configured, if no patterns are configured all files are discovered
+* From those files validate that they match at least one of the patterns configured. If no patterns are configured, then all files are discovered
 * The agent then creates an API service and revision to represent that specification file in Amplify Central
-* If the files is of a known specification type then the service will be marked with that type, otherwise the service will have a type of `Unstructured`
+* If the files are of a known specification type, then the service will be marked with that type. Otherwise, the service will have a type of `Unstructured`
 
 ### Installation via CLI
 
@@ -98,7 +98,7 @@ If you are a member of multiple Amplify organizations, you may have to choose an
 
 ### Step 3: Run the agents' configure procedure
 
-The Axway Central CLI will guide you through the configuration of the agents. See [Embedded GitHub agents setup](/docs/connect_manage_environ/connect_github_repository/embedded-agent-setup/) for the prerequisite setup on GCP and Apigee.
+The Axway Central CLI will guide you through the configuration of the agents. See [Embedded GitHub agents' setup](/docs/connect_manage_environ/connect_github_repository/embedded-agent-setup/) for the prerequisite setup on GCP and Apigee.
 
 Run the following command to start the configuration procedure:
 
@@ -121,6 +121,6 @@ The installation procedure will prompt for the following:
    * **Paths**: the paths that the agent will look for specs in, paths should start with a `/` character
    * **Filename Patterns**: the patterns that a filename must match to be discovered
      * The pattens here are regular expressions [RE2 Syntax](https://github.com/google/re2/wiki/Syntax), only one pattern must match to discover a specification file
-     * The pattern will pass if it matches any part of the filename, if the desire is to match the whole name then adding anchors to the expression should be used (ex: `^spec\.json$`, this will match only files that literally named `spec.json`)
+     * The pattern will pass if it matches any part of the filename. To match the whole name, add anchors to the expression (ex: `^spec\.json$`, this will match only files that literally named `spec.json`)
 
 Once you have answered all questions, the Embedded agent will be created. The process will securely store the authentication data and validate it by connecting to GitHub. If set to discover GitHub resources upon installation, the agent will immediately discover your resources and show them in the Service Registry.

--- a/content/en/docs/connect_manage_environ/connect_github_repository/embedded-agent-setup.md
+++ b/content/en/docs/connect_manage_environ/connect_github_repository/embedded-agent-setup.md
@@ -1,0 +1,29 @@
+---
+title: Set up GitHub for Embedded agents
+linkTitle: Set up GitHub for Embedded agents
+draft: false
+weight: 100
+---
+Set up GitHub so an Embedded agent can connect to and discover API specifications to publish in Amplify.
+
+## Before you start
+
+* You must have access to GitHub and the ability to create a user Access Token that the agent can use to connect to the desired repository.
+
+## Objectives
+
+Learn how to quickly set up a GitHub access token to allow the agent to discover API specification files in your repository.
+
+## GitHub setup
+
+The Embedded agent uses a personal access token to read your repository, this token does not need any access other than read. See [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+
+1. Within a browser navigate to GitHub.
+2. Navigate to *Settings* for your user profile.
+3. Click *Developer settings* at the bottom of the left navigation.
+4. Select *Personal access tokens* and then *Tokens (classic)*.
+5. Click *Generate new token* and then *Generate new token (classic)*.
+6. Set an expiration time according to your organizations policy.
+7. Do not click and boxes granting more privileges.
+8. At the common click *Generate token*.
+9. Save the token for installation.

--- a/content/en/docs/connect_manage_environ/connect_github_repository/embedded-agent-setup.md
+++ b/content/en/docs/connect_manage_environ/connect_github_repository/embedded-agent-setup.md
@@ -8,7 +8,7 @@ Set up GitHub so an Embedded agent can connect to and discover API specification
 
 ## Before you start
 
-* You must have access to GitHub and the ability to create a user Access Token that the agent can use to connect to the desired repository.
+* You must have access to GitHub and the ability to create a user access token that the agent can use to connect to the desired repository.
 
 ## Objectives
 
@@ -18,12 +18,12 @@ Learn how to quickly set up a GitHub access token to allow the agent to discover
 
 The Embedded agent uses a personal access token to read your repository, this token does not need any access other than read. See [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
 
-1. Within a browser navigate to GitHub.
+1. Within a browser, navigate to GitHub.
 2. Navigate to *Settings* for your user profile.
-3. Click *Developer settings* at the bottom of the left navigation.
-4. Select *Personal access tokens* and then *Tokens (classic)*.
-5. Click *Generate new token* and then *Generate new token (classic)*.
+3. Click **Developer settings** at the bottom of the left navigation.
+4. Select **Personal access tokens** and then **Tokens (classic)**.
+5. Click **Generate new token** and then **Generate new token (classic)**.
 6. Set an expiration time according to your organizations policy.
-7. Do not click and boxes granting more privileges.
-8. At the common click *Generate token*.
+7. Do not click any boxes granting more privileges.
+8. At the common, click **Generate token**.
 9. Save the token for installation.


### PR DESCRIPTION
Thank you for your contribution to the Amplify-Central repo.

## Describe the changes

Add documentation on how to setup and install a GitHub discovery agent

## Deploy preview link

* http://pr-366.amplify-central.opendocs-builder.pcloud.axway.int/docs/connect_manage_environ/connect_github_repository/
* http://pr-366.amplify-central.opendocs-builder.pcloud.axway.int/docs/connect_manage_environ/connect_github_repository/embedded-agent-setup/

## Checklist for contributors

Before submitting this PR:

* Verify that all status checks have passed
* For more information on the Markdown linter rules, see [DavidAnson/markdownlint](https://github.com/DavidAnson/markdownlint)
* For first-time contributors, ensure that you have signed the [Axway CLA](https://cla.axway.com/)
