### PR TITLE
Update region information

### DIFF
--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
@@ -41,8 +41,6 @@ All outbound traffic is sent over SSL via TCP / UDP.
 
 Open the following ports so that agents can communicate to the Amplify platform:
 
-Robert, please update table.
-
 | Region | Host                       | IP             | port | Protocol | data                                 |
 | ------ | -------------------------- | -------------- | ---- | -------- | ------------------------------------ |
 |        |                            |                |      |          |                                      |
@@ -57,8 +55,6 @@ Robert, please update table.
 | EU     | central.eu-fr.axway.com    | 52.47.84.198   | 443  | HTTPS    | API definitions, Subscription info   |
 |        |                            | 13.36.25.69    |      |          |                                      |
 |        |                            | 35.181.21.87   |      |          |                                      |
-|        |                            |                |      |          |                                      |
-| AP/EU/US | lighthouse.admin.axway.com |                | 443  | HTTPS    | API usage event for online mode only |
 |        |                            |                |      |          |                                      |
 | AP     | central.ap-sg.axway.com    | 122.248.205.123 | 443  | HTTPS    | API definitions, Subscription info   |
 |        |                            | 18.138.187.120  |      |          |                                      |

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
@@ -60,10 +60,10 @@ Open the following ports so that agents can communicate to the Amplify platform:
 |        |                            | 18.138.187.120  |      |          |                                      |
 |        |                            | 52.220.146.36   |      |          |                                      |
 |        |                            |                |      |          |                                      |
-| AP/EU/US | platform.axway.com/usage | ?.?.?.?        | 443  | HTTPS    | Usage metrics                                     |
+| AP/EU/US | platform.axway.coe       | ?.?.?.?        | 443  | HTTPS    | Usage metrics                                     |
 |        |                            |                |      |          |                                      |
 
-
+   
 {{< alert title="Note" color="primary" >}}
 *Region* column represents the region where your Amplify organization is deployed. EU means deployed in European data center, AP means deployed in Asia Pacific data center and US meaning deployed in US data center. You must use the corresponding *Host*/*Port* for your agents to operate correctly.
 {{< /alert >}}

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
@@ -64,7 +64,7 @@ Open the following ports so that agents can communicate to the Amplify platform:
 |        |                            |                |      |          |                                      |
 
 {{< alert title="Note" color="primary" >}}
-*Region* column represents the region where your Amplify organization is deployed. EU means deployed in European data center, AP means deployed in Asia Pacific data center and US meaning deployed in US data center. You must use the corresponding *Host*/*Port* for your agents to operate correctly.
+*Region* column represents the region where your Amplify organization is deployed. EU means deployed in European data center, AP means deployed in Asia Pacific data center and US meaning deployed in US data center. You must use the corresponding *Host* / *Port* for your agents to operate correctly.
 {{< /alert >}}
 
 {{< alert title="Note" color="primary" >}}

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
@@ -62,7 +62,6 @@ Open the following ports so that agents can communicate to the Amplify platform:
 |        |                            |                |      |          |                                      |
 | AP/EU/US | platform.axway.com       | Dynamic        | 443  | HTTPS    | Usage metrics                                     |
 |        |                            |                |      |          |                                      |
-
    
 {{< alert title="Note" color="primary" >}}
 *Region* column represents the region where your Amplify organization is deployed. EU means deployed in European data center, AP means deployed in Asia Pacific data center and US meaning deployed in US data center. You must use the corresponding *Host*/*Port* for your agents to operate correctly.

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
@@ -46,7 +46,7 @@ Robert, please update table.
 | Region | Host                       | IP             | port | Protocol | data                                 |
 | ------ | -------------------------- | -------------- | ---- | -------- | ------------------------------------ |
 |        |                            |                |      |          |                                      |
-| EU/US  | login.axway.com            | 52.58.132.2    | 443  | HTTPS    | Platform authentication              |
+| AP/EU/US | login.axway.com            | 52.58.132.2    | 443  | HTTPS    | Platform authentication              |
 |        |                            | 52.29.4.35     |      |          |                                      |
 |        |                            | 54.93.140.145  |      |          |                                      |
 |        |                            |                |      |          |                                      |
@@ -60,9 +60,11 @@ Robert, please update table.
 |        |                            |                |      |          |                                      |
 | EU/US  | lighthouse.admin.axway.com |                | 443  | HTTPS    | API usage event for online mode only |
 |        |                            |                |      |          |                                      |
+| AP     | central.ap-sg.axway.com    | ?.?.?.?        | 443  | HTTPS    | API definitions, Subscription info   |
+|        |                            |                |      |          |                                      |
 
 {{< alert title="Note" color="primary" >}}
-*Region* column represents the region where your Amplify organization is deployed. EU means deployed in European data center and US meaning deployed in US data center. You must use the corresponding *Host*/*Port* for your agents to operate correctly.
+*Region* column represents the region where your Amplify organization is deployed. EU means deployed in European data center, AP means deployed in Asia Pacific data center and US meaning deployed in US data center. You must use the corresponding *Host*/*Port* for your agents to operate correctly.
 {{< /alert >}}
 
 {{< alert title="Note" color="primary" >}}

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
@@ -62,7 +62,7 @@ Open the following ports so that agents can communicate to the Amplify platform:
 |        |                            |                |      |          |                                      |
 | AP/EU/US | platform.axway.com       | Dynamic        | 443  | HTTPS    | Usage metrics                                     |
 |        |                            |                |      |          |                                      |
-   
+
 {{< alert title="Note" color="primary" >}}
 *Region* column represents the region where your Amplify organization is deployed. EU means deployed in European data center, AP means deployed in Asia Pacific data center and US meaning deployed in US data center. You must use the corresponding *Host*/*Port* for your agents to operate correctly.
 {{< /alert >}}

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
@@ -41,6 +41,8 @@ All outbound traffic is sent over SSL via TCP / UDP.
 
 Open the following ports so that agents can communicate to the Amplify platform:
 
+Robert, please update table.
+
 | Region | Host                       | IP             | port | Protocol | data                                 |
 | ------ | -------------------------- | -------------- | ---- | -------- | ------------------------------------ |
 |        |                            |                |      |          |                                      |

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
@@ -60,6 +60,8 @@ Open the following ports so that agents can communicate to the Amplify platform:
 |        |                            | 18.138.187.120  |      |          |                                      |
 |        |                            | 52.220.146.36   |      |          |                                      |
 |        |                            |                |      |          |                                      |
+| AP/EU/US | platform.axway.com/usage | ?.?.?.?        | 443  | HTTPS    | Usage metrics                                     |
+|        |                            |                |      |          |                                      |
 
 
 {{< alert title="Note" color="primary" >}}

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
@@ -60,7 +60,7 @@ Open the following ports so that agents can communicate to the Amplify platform:
 |        |                            | 18.138.187.120  |      |          |                                      |
 |        |                            | 52.220.146.36   |      |          |                                      |
 |        |                            |                |      |          |                                      |
-| AP/EU/US | platform.axway.coe       | ?.?.?.?        | 443  | HTTPS    | Usage metrics                                     |
+| AP/EU/US | platform.axway.com       | Dynamic        | 443  | HTTPS    | Usage metrics                                     |
 |        |                            |                |      |          |                                      |
 
    

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/traceability_usage.md
@@ -58,10 +58,13 @@ Robert, please update table.
 |        |                            | 13.36.25.69    |      |          |                                      |
 |        |                            | 35.181.21.87   |      |          |                                      |
 |        |                            |                |      |          |                                      |
-| EU/US  | lighthouse.admin.axway.com |                | 443  | HTTPS    | API usage event for online mode only |
+| AP/EU/US | lighthouse.admin.axway.com |                | 443  | HTTPS    | API usage event for online mode only |
 |        |                            |                |      |          |                                      |
-| AP     | central.ap-sg.axway.com    | ?.?.?.?        | 443  | HTTPS    | API definitions, Subscription info   |
+| AP     | central.ap-sg.axway.com    | 122.248.205.123 | 443  | HTTPS    | API definitions, Subscription info   |
+|        |                            | 18.138.187.120  |      |          |                                      |
+|        |                            | 52.220.146.36   |      |          |                                      |
 |        |                            |                |      |          |                                      |
+
 
 {{< alert title="Note" color="primary" >}}
 *Region* column represents the region where your Amplify organization is deployed. EU means deployed in European data center, AP means deployed in Asia Pacific data center and US meaning deployed in US data center. You must use the corresponding *Host*/*Port* for your agents to operate correctly.

--- a/content/en/docs/integrate_with_central/cli_central/_index.md
+++ b/content/en/docs/integrate_with_central/cli_central/_index.md
@@ -23,7 +23,9 @@ Before you start, you must have credentials or a service account to use the CLI.
 
 ## Overview of the Axway Central CLI capabilities
 
-### Fetching resources
+Manage your resources with Axway Central CLI.
+
+### Fetch resources
 
 To view all resource types that are available in the system, run the following `get` command and provide an argument as to which type to get:
 
@@ -56,7 +58,7 @@ axway central get <Resource1>,<Resource2>,...,<ResourceN> # Get a list of multip
 axway central get <Resource> <Name> -s/--scope <Scope Name> # Get a specific resource by name in a named scope
 ```
 
-### Fetching all the details of a resource
+### Fetch all the details of a resource
 
 By default, results of the `get` command are outputted in table format. You can see additional information for the resource if you use the `-output` argument and request for the result to be rendered in yaml or json.
 
@@ -96,7 +98,7 @@ spec:
   description: Azure Environment
 ```
 
-### Creating resources
+### Create resources
 
 Create resources using the `create` command. To create a resource, provided the `create` a resource definition in a file. json and yaml formats are accepted. Note that multiple resources can be in a single file if each resource is separated by three dashes `---`.
 Alternatively, an empty resource can be created by providing only a value for the resource's name.
@@ -130,7 +132,7 @@ To create an empty resource that represents an environment resource type with a 
 axway central create environment helloworld
 ```
 
-### Updating resources
+### Update resources
 
 Update resources using the `apply` command. The apply command accepts a file containing the resource(s) to be updated. json and yaml formats are accepted.
 
@@ -138,7 +140,7 @@ Update resources using the `apply` command. The apply command accepts a file con
 axway central apply -f delete.yaml
 ```
 
-### Deleting resources
+### Delete resources
 
 Delete resources from the API Server using the `delete command`. The Delete command can accept resource name or file name containing the resource definition. json and yaml formats are accepted.
 

--- a/content/en/docs/integrate_with_central/cli_central/_index.md
+++ b/content/en/docs/integrate_with_central/cli_central/_index.md
@@ -45,7 +45,7 @@ To view all resource types that are available in the system if your organization
 axway central get --region=AP
 ```
 
-NOTE: The additional parameter of '--region=EU' or --region=AP will execute any Axway Central commnand in the EU or APAC region specifically.  
+{{< alert title="Note" color="primary" >}}The additional parameter of `--region=EU` or `--region=AP` will execute any Axway Central command in the EU or APAC region specifically.{{< /alert >}}  
 
 The result from the `get` command lists the available types in the API Server and the results are displayed in a table with the following columns:
 

--- a/content/en/docs/integrate_with_central/cli_central/_index.md
+++ b/content/en/docs/integrate_with_central/cli_central/_index.md
@@ -45,7 +45,7 @@ To view all resource types that are available in the system if your organization
 axway central get --region=AP
 ```
 
-NOTE: The additional parameter of '--region=EU' or --region=AP will execute Axway Central commnand in the EU or APAC region specifically.  
+NOTE: The additional parameter of '--region=EU' or --region=AP will execute any Axway Central commnand in the EU or APAC region specifically.  
 
 The result from the `get` command lists the available types in the API Server and the results are displayed in a table with the following columns:
 

--- a/content/en/docs/integrate_with_central/cli_central/_index.md
+++ b/content/en/docs/integrate_with_central/cli_central/_index.md
@@ -33,6 +33,20 @@ To view all resource types that are available in the system, run the following `
 axway central get 
 ```
 
+To view all resource types that are available in the system if your organization is in the EU region, run the following `get` command and provide an argument as to which type to get:
+
+```bash
+axway central get --region=EU
+```
+
+To view all resource types that are available in the system if your organization is in the APAC region, run the following `get` command and provide an argument as to which type to get:
+
+```bash
+axway central get --region=AP
+```
+
+NOTE: The additional parameter of '--region=EU' or --region=AP will execute Axway Central commnand in the EU or APAC region specifically.  
+
 The result from the `get` command lists the available types in the API Server and the results are displayed in a table with the following columns:
 
 | Name      | Description |

--- a/content/en/docs/integrate_with_central/cli_central/cli_asset_catalog.md
+++ b/content/en/docs/integrate_with_central/cli_central/cli_asset_catalog.md
@@ -30,6 +30,8 @@ You'll also learn how to create an asset for an SDK.
 
 Assets can represent any digital entity – SDKs, docs, REST API, WSDL, gif etc. – whatever you want to catalog and productize, APIs being the primary use case for assets in the system. The lifecycle of those productizable APIs is nebulous, as the decisions on how they can be grouped and managed is a business decision. A “stage” is a grouping mechanism, but it’s not got a concrete physical representation (i.e., tied to an environment). It could be dev/test/prod, it could be eu/us/cn, it could be R&D/Sales/Marketing.
 
+Robert, please update this section. See references to eu/us/cn above.
+
 Run the following command to list the available stages in the system:
 
 ```bash

--- a/content/en/docs/integrate_with_central/cli_central/cli_asset_catalog.md
+++ b/content/en/docs/integrate_with_central/cli_central/cli_asset_catalog.md
@@ -28,9 +28,7 @@ You'll also learn how to create an asset for an SDK.
 
 ### Group an asset in a stage
 
-Assets can represent any digital entity – SDKs, docs, REST API, WSDL, gif etc. – whatever you want to catalog and productize, APIs being the primary use case for assets in the system. The lifecycle of those productizable APIs is nebulous, as the decisions on how they can be grouped and managed is a business decision. A “stage” is a grouping mechanism, but it’s not got a concrete physical representation (i.e., tied to an environment). It could be dev/test/prod, it could be eu/us/cn, it could be R&D/Sales/Marketing.
-
-Robert, please update this section. See references to eu/us/cn above.
+Assets can represent any digital entity – SDKs, docs, REST API, WSDL, gif etc. – whatever you want to catalog and productize, APIs being the primary use case for assets in the system. The lifecycle of those productizable APIs is nebulous, as the decisions on how they can be grouped and managed is a business decision. A “stage” is a grouping mechanism, but it’s not got a concrete physical representation (i.e., tied to an environment). It could be dev/test/prod, it could be eu/us/cn/ap, it could be R&D/Sales/Marketing.
 
 Run the following command to list the available stages in the system:
 

--- a/content/en/docs/integrate_with_central/cli_central/cli_asset_catalog.md
+++ b/content/en/docs/integrate_with_central/cli_central/cli_asset_catalog.md
@@ -28,7 +28,7 @@ You'll also learn how to create an asset for an SDK.
 
 ### Group an asset in a stage
 
-Assets can represent any digital entity – SDKs, docs, REST API, WSDL, gif etc. – whatever you want to catalog and productize, APIs being the primary use case for assets in the system. The lifecycle of those productizable APIs is nebulous, as the decisions on how they can be grouped and managed is a business decision. A “stage” is a grouping mechanism, but it’s not got a concrete physical representation (i.e., tied to an environment). It could be dev/test/prod, it could be eu/us/cn/ap, it could be R&D/Sales/Marketing.
+Assets can represent any digital entity (SDKs, docs, REST APIs, WSDL, GIF, etc.), whatever you want to catalog and productize, with APIs being the primary use case for assets in the system. The lifecycle of those productizable APIs is nebulous, as the decisions on how they can be grouped and managed is a business decision. A "stage" is a grouping mechanism, which isn't tied to an environment and does not have a concrete physical representation. It could be, for example, dev/test/prod, eu/us/cn/ap, or R&D/Sales/Marketing.
 
 Run the following command to list the available stages in the system:
 
@@ -42,7 +42,7 @@ Run the following command to list the available stages for an organization in th
 axway central get stg --region=EU
 ```
 
-{{< alert title="Note" color="primary" >}}The additional parameter of '--region=EU' or --region=AP will execute any Axway Central commannd in the EU or APAC region specifically.{{< /alert >}}
+{{< alert title="Note" color="primary" >}}The additional parameter of `--region=EU` or `--region=AP` will execute any Axway Central command in the EU or APAC region specifically.{{< /alert >}}
 
 Run the following command to get details of the stages, including their logical name:
 

--- a/content/en/docs/integrate_with_central/cli_central/cli_asset_catalog.md
+++ b/content/en/docs/integrate_with_central/cli_central/cli_asset_catalog.md
@@ -36,6 +36,13 @@ Run the following command to list the available stages in the system:
 axway central get stg
 ```
 
+Run the following command to list the available stages for an organization in the EU region:
+
+```bash
+axway central get stg --region=EU
+```
+NOTE: The additional parameter of '--region=EU' or --region=AP will execute any Axway Central commnand in the EU or APAC region specifically.
+
 Run the following command to get details of the stages, including their logical name:
 
 ```bash

--- a/content/en/docs/integrate_with_central/cli_central/cli_asset_catalog.md
+++ b/content/en/docs/integrate_with_central/cli_central/cli_asset_catalog.md
@@ -41,7 +41,8 @@ Run the following command to list the available stages for an organization in th
 ```bash
 axway central get stg --region=EU
 ```
-NOTE: The additional parameter of '--region=EU' or --region=AP will execute any Axway Central commnand in the EU or APAC region specifically.
+
+{{< alert title="Note" color="primary" >}}The additional parameter of '--region=EU' or --region=AP will execute any Axway Central commannd in the EU or APAC region specifically.{{< /alert >}}
 
 Run the following command to get details of the stages, including their logical name:
 

--- a/content/en/docs/integrate_with_central/platform-auth-examples.md
+++ b/content/en/docs/integrate_with_central/platform-auth-examples.md
@@ -83,6 +83,14 @@ The following command will fulfill the authorization flow and cause the client I
 axway auth login --client-id sa-test_6d66dc36-f838-4006-8c44-5340d4698be5 --client-secret c961d6f2-8596-4ec3-9aca-0b32f49bf328 --json
 ```
 
+The following command will fulfill the authorization flow and cause the client ID and Secret to be base64 encoded, passed to the auth server and then subsequently use the token to call platform services in the EU region:
+
+```shell
+axway auth login --client-id sa-test_6d66dc36-f838-4006-8c44-5340d4698be5 --client-secret c961d6f2-8596-4ec3-9aca-0b32f49bf328 --json --region=EU
+```
+
+NOTE: The additional parameter of '--region=EU' or --region=AP will execute any Axway Central commnand in the EU or APAC region specifically.
+
 You can extract and use the token from the resulting JSON response:
 
 ```json

--- a/content/en/docs/integrate_with_central/platform-auth-examples.md
+++ b/content/en/docs/integrate_with_central/platform-auth-examples.md
@@ -89,7 +89,7 @@ The following command will fulfill the authorization flow and cause the client I
 axway auth login --client-id sa-test_6d66dc36-f838-4006-8c44-5340d4698be5 --client-secret c961d6f2-8596-4ec3-9aca-0b32f49bf328 --json --region=EU
 ```
 
-NOTE: The additional parameter of '--region=EU' or --region=AP will execute any Axway Central commnand in the EU or APAC region specifically.
+{{< alert title="Note" color="primary" >}}The additional parameter of `--region=EU` or `--region=AP` will execute any Axway Central command in the EU or APAC region specifically.{{< /alert >}}
 
 You can extract and use the token from the resulting JSON response:
 

--- a/content/en/docs/integrate_with_central/platform-auth-examples.md
+++ b/content/en/docs/integrate_with_central/platform-auth-examples.md
@@ -33,7 +33,7 @@ A service account is an Amplify concept that allows a non-user, such as a CLI or
 
 5. Select the appropriate role for this service account. In this example, Central Admin is used. Your service account should now be created.
 
-    ![service acoount dialog screen](/Images/integration/create-service-account.png)
+    ![service account dialog screen](/Images/integration/create-service-account.png)
   
 6. Take note of the Client ID and Secret. You will need to remember or store the secret securely, as this is the only time it will ever be displayed.
 
@@ -45,7 +45,7 @@ A service account is an Amplify concept that allows a non-user, such as a CLI or
 
 ### Create the service account with the UI
 
-1. Sign into the Amplify platform and select **Organization** from the User drop-down menu.
+1. Sign in to the Amplify platform and select **Organization** from the User drop-down menu.
 
     ![organization drop down screen](/Images/integration/organization-drop-down.png)
 

--- a/content/en/docs/integrate_with_central/query-the-traceability-apis-with-lexus.md
+++ b/content/en/docs/integrate_with_central/query-the-traceability-apis-with-lexus.md
@@ -619,7 +619,7 @@ Extend the previous call to also include the API paths called.
 
 ### Transactions by status code
 
-The count of transactionSummaries for a particular environment, grouped by status code. Note statuses are 1XX, 2XX, 3XX, so the interval of "100" will group them into those buckets.
+The count of transactionSummaries for a particular environment, grouped by status code. Note that statuses are 1XX, 2XX, 3XX, so the interval of "100" will group them into those buckets.
 
 ```json
 {

--- a/content/en/docs/integrate_with_central/query-the-traceability-apis-with-lexus.md
+++ b/content/en/docs/integrate_with_central/query-the-traceability-apis-with-lexus.md
@@ -619,7 +619,9 @@ Extend the previous call to also include the API paths called.
 
 ### Transactions by status code
 
-The count of transactionSummaries for a particular environment, grouped by status code. Note that statuses are 1XX, 2XX, 3XX, so the interval of "100" will group them into those buckets.
+The count of transactionSummaries for a particular environment, grouped by status code. 
+
+{{< alert title="Note" color="primary" >}}The statuses are 1XX, 2XX, 3XX, so the interval of "100" will group them into those buckets.{{< /alert >}}
 
 ```json
 {

--- a/content/en/docs/integrate_with_central/query-the-traceability-apis-with-lexus.md
+++ b/content/en/docs/integrate_with_central/query-the-traceability-apis-with-lexus.md
@@ -619,7 +619,7 @@ Extend the previous call to also include the API paths called.
 
 ### Transactions by status code
 
-The count of transactionSummaries for a particular environment, grouped by status code. 
+The count of transactionSummaries for a particular environment, grouped by status code.
 
 {{< alert title="Note" color="primary" >}}The statuses are 1XX, 2XX, 3XX, so the interval of "100" will group them into those buckets.{{< /alert >}}
 

--- a/content/en/docs/manage_asset_catalog/asset_integrate_api_cli.md
+++ b/content/en/docs/manage_asset_catalog/asset_integrate_api_cli.md
@@ -28,6 +28,8 @@ Learn how to use the Axway Central CLI to create and manage assets in the Asset 
 
 Assets can represent any digital entity (sdks, docs, REST API, WSDL, gif, etc.) that you want to catalog and productize, with APIs being the primary use case for assets in the system. The lifecycle of the APIs that can be productized is a business decision which determines how they are grouped and managed. A “stage” is a grouping mechanism, which isn't tied to an environment and does not have a concrete physical representation. It could be, for example, dev/test/prod, eu/us/cn, or R&D/Sales/Marketing.
 
+Robert, please update this section. See references to eu/us/cn above.
+
 ### List available stages
 
 To see the list of currently available stages in the system, run the following command:

--- a/content/en/docs/manage_asset_catalog/asset_integrate_api_cli.md
+++ b/content/en/docs/manage_asset_catalog/asset_integrate_api_cli.md
@@ -26,9 +26,7 @@ Learn how to use the Axway Central CLI to create and manage assets in the Asset 
 
 ## Group an asset in a stage
 
-Assets can represent any digital entity (sdks, docs, REST API, WSDL, gif, etc.) that you want to catalog and productize, with APIs being the primary use case for assets in the system. The lifecycle of the APIs that can be productized is a business decision which determines how they are grouped and managed. A “stage” is a grouping mechanism, which isn't tied to an environment and does not have a concrete physical representation. It could be, for example, dev/test/prod, eu/us/cn, or R&D/Sales/Marketing.
-
-Robert, please update this section. See references to eu/us/cn above.
+Assets can represent any digital entity (sdks, docs, REST API, WSDL, gif, etc.) that you want to catalog and productize, with APIs being the primary use case for assets in the system. The lifecycle of the APIs that can be productized is a business decision which determines how they are grouped and managed. A “stage” is a grouping mechanism, which isn't tied to an environment and does not have a concrete physical representation. It could be, for example, dev/test/prod, eu/us/cn/ap, or R&D/Sales/Marketing.
 
 ### List available stages
 

--- a/content/en/docs/manage_asset_catalog/asset_integrate_api_cli.md
+++ b/content/en/docs/manage_asset_catalog/asset_integrate_api_cli.md
@@ -36,6 +36,14 @@ To see the list of currently available stages in the system, run the following c
 axway central get stg
 ```
 
+To see the list of currently available stages in the system for an organization in the EU region, run the following command:
+
+```bash
+axway central get stg --region=EU
+```
+
+NOTE: The additional parameter of '--region=EU' or --region=AP will execute any Axway Central commnand in the EU or APAC region specifically.
+
 ### Get details
 
 To get the details of the stages, including their logical names, run the following command:

--- a/content/en/docs/manage_asset_catalog/asset_integrate_api_cli.md
+++ b/content/en/docs/manage_asset_catalog/asset_integrate_api_cli.md
@@ -26,7 +26,7 @@ Learn how to use the Axway Central CLI to create and manage assets in the Asset 
 
 ## Group an asset in a stage
 
-Assets can represent any digital entity (sdks, docs, REST API, WSDL, gif, etc.) that you want to catalog and productize, with APIs being the primary use case for assets in the system. The lifecycle of the APIs that can be productized is a business decision which determines how they are grouped and managed. A “stage” is a grouping mechanism, which isn't tied to an environment and does not have a concrete physical representation. It could be, for example, dev/test/prod, eu/us/cn/ap, or R&D/Sales/Marketing.
+Assets can represent any digital entity (SDKs, docs, REST APIs, WSDL, GIF, etc.), whatever you want to catalog and productize, with APIs being the primary use case for assets in the system. The lifecycle of those productizable APIs is nebulous, as the decisions on how they can be grouped and managed is a business decision. A "stage" is a grouping mechanism, which isn't tied to an environment and does not have a concrete physical representation. It could be, for example, dev/test/prod, eu/us/cn/ap, or R&D/Sales/Marketing.
 
 ### List available stages
 
@@ -42,7 +42,7 @@ To see the list of currently available stages in the system for an organization 
 axway central get stg --region=EU
 ```
 
-NOTE: The additional parameter of '--region=EU' or --region=AP will execute any Axway Central commnand in the EU or APAC region specifically.
+{{< alert title="Note" color="primary" >}}The additional parameter of `--region=EU` or `--region=AP` will execute any Axway Central command in the EU or APAC region specifically.{{< /alert >}}
 
 ### Get details
 


### PR DESCRIPTION
Thank you for your contribution to the Amplify-Central repo.

## Describe the changes

Besides your intended changes, please add these additional region changes. Issue opened @ https://github.com/Axway/amplify-central/issues/422. 

    Currently, most of the pages referencing the Central URL are using the US one. But since we added multiple regions EU/APAC, it is not clear which URL should be used.

    Problem locations:

    * https://docs.axway.com/bundle/amplify-central/page/docs/integrate_with_central/platform-auth-examples/index.html
    * https://docs.axway.com/bundle/amplify-central/page/docs/integrate_with_central/query-the-traceability-apis-with-lexus/index.html
    * https://docs.axway.com/bundle/amplify-central/page/docs/integrate_with_central/cli_central/index.html (need to mention the --region parameter)

## Deploy preview link

Please add the deploy preview link to the **specific page** that you've changed.

## Checklist for contributors

Before submitting this PR:

* Verify that all status checks have passed
* For more information on the Markdown linter rules, see [DavidAnson/markdownlint](https://github.com/DavidAnson/markdownlint)
* For first-time contributors, ensure that you have signed the [Axway CLA](https://cla.axway.com/)
