### PR TITLE
Replace charts.axway.com with repository.axway.com

### DIFF
--- a/content/en/docs/connect_manage_environ/connect_api_manager/deploy-your-agents-with-amplify-cli.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/deploy-your-agents-with-amplify-cli.md
@@ -259,7 +259,7 @@ persistentVolumeClaimConfig:
 The agents can be deployed with the following commands, which are mentioned at the end of the CLI install prompts:
 
 ```bash
-helm repo add axway https://charts.axway.com/charts
+helm repo add axway https://repository.axway.com/charts
 helm repo update
 helm upgrade --install --namespace <YOUR_NAMESPACE> v7-discovery axway/v7-discovery -f da-overrides.yaml
 helm upgrade --install --namespace <YOUR_NAMESPACE> v7-traceability axway/v7-traceability -f ta-overrides.yaml

--- a/content/en/docs/connect_manage_environ/connect_api_manager/deploy-your-agents-with-amplify-cli.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/deploy-your-agents-with-amplify-cli.md
@@ -261,7 +261,6 @@ The agents can be deployed with the following commands, which are mentioned at t
 
 ```bash
 helm repo add axway https://helm.repository.axway.com --username==<client-id> --password=<client_secret>
-helm repo pull <agent_filename>
 helm repo update
 helm upgrade --install --namespace <YOUR_NAMESPACE> v7-discovery axway/ampc-beano-help-prod-v7-discovery -f da-overrides.yaml
 helm upgrade --install --namespace <YOUR_NAMESPACE> v7-traceability axway/ampc-beano-helm-v7-traceability -f ta-overrides.yaml

--- a/content/en/docs/connect_manage_environ/connect_api_manager/deploy-your-agents-with-amplify-cli.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/deploy-your-agents-with-amplify-cli.md
@@ -259,8 +259,8 @@ persistentVolumeClaimConfig:
 The agents can be deployed with the following commands, which are mentioned at the end of the CLI install prompts:
 
 ```bash
-helm repo add axway https://repository.axway.com/charts
-helm repo update
+helm repo add axway https://repository.axway.com --username==<client-id> --password=<client_secret>
+helm repo pull <agent_filename>
 helm upgrade --install --namespace <YOUR_NAMESPACE> v7-discovery axway/v7-discovery -f da-overrides.yaml
 helm upgrade --install --namespace <YOUR_NAMESPACE> v7-traceability axway/v7-traceability -f ta-overrides.yaml
 ```

--- a/content/en/docs/connect_manage_environ/connect_api_manager/deploy-your-agents-with-amplify-cli.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/deploy-your-agents-with-amplify-cli.md
@@ -262,8 +262,9 @@ The agents can be deployed with the following commands, which are mentioned at t
 ```bash
 helm repo add axway https://helm.repository.axway.com --username==<client-id> --password=<client_secret>
 helm repo pull <agent_filename>
-helm upgrade --install --namespace <YOUR_NAMESPACE> v7-discovery axway/v7-discovery -f da-overrides.yaml
-helm upgrade --install --namespace <YOUR_NAMESPACE> v7-traceability axway/v7-traceability -f ta-overrides.yaml
+helm repo update
+helm upgrade --install --namespace <YOUR_NAMESPACE> v7-discovery axway/ampc-beano-help-prod-v7-discovery -f da-overrides.yaml
+helm upgrade --install --namespace <YOUR_NAMESPACE> v7-traceability axway/ampc-beano-helm-v7-traceability -f ta-overrides.yaml
 ```
 
 ### Linux Service mode for binary agent

--- a/content/en/docs/connect_manage_environ/connect_api_manager/deploy-your-agents-with-amplify-cli.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/deploy-your-agents-with-amplify-cli.md
@@ -256,10 +256,11 @@ persistentVolumeClaimConfig:
     storageClass: gp2-csi
 ```
 
+The helm charts for the agents and download instructions can be found at https:/repository.axway.com/catalog.
 The agents can be deployed with the following commands, which are mentioned at the end of the CLI install prompts:
 
 ```bash
-helm repo add axway https://repository.axway.com --username==<client-id> --password=<client_secret>
+helm repo add axway https://helm.repository.axway.com --username==<client-id> --password=<client_secret>
 helm repo pull <agent_filename>
 helm upgrade --install --namespace <YOUR_NAMESPACE> v7-discovery axway/v7-discovery -f da-overrides.yaml
 helm upgrade --install --namespace <YOUR_NAMESPACE> v7-traceability axway/v7-traceability -f ta-overrides.yaml

--- a/content/en/docs/connect_manage_environ/mesh_management/build_hybrid_env.md
+++ b/content/en/docs/connect_manage_environ/mesh_management/build_hybrid_env.md
@@ -79,7 +79,7 @@ Install Helm on your cluster and add the Axway public repository to Helm:
 2. Add the Axway public Helm repository to your installation:
 
    ```bash
-   helm repo add axway https://charts.axway.com/charts
+   helm repo add axway https://repository.axway.com/charts
    "axway" has been added to your repositories
    ```
 3. Verify that the Axway public repository has been added:
@@ -89,7 +89,7 @@ Install Helm on your cluster and add the Axway public repository to Helm:
    NAME            URL
    stable          https://kubernetes-charts.storage.googleapis.com
    local           http://127.0.0.1:8879/charts
-   axway           https://charts.axway.com/charts
+   axway           https://repository.axway.com/charts
    ```
 
 ## Validate the Amazon EC2 hybrid environment

--- a/content/en/docs/connect_manage_environ/mesh_management/build_hybrid_env.md
+++ b/content/en/docs/connect_manage_environ/mesh_management/build_hybrid_env.md
@@ -79,7 +79,7 @@ Install Helm on your cluster and add the Axway public repository to Helm:
 2. Add the Axway public Helm repository to your installation:
 
    ```bash
-   helm repo add axway https://repository.axway.com/charts
+   helm repo add axway https://repository.axway.com --username==<client-id> --password=<client_secret>
    "axway" has been added to your repositories
    ```
 3. Verify that the Axway public repository has been added:
@@ -89,7 +89,7 @@ Install Helm on your cluster and add the Axway public repository to Helm:
    NAME            URL
    stable          https://kubernetes-charts.storage.googleapis.com
    local           http://127.0.0.1:8879/charts
-   axway           https://repository.axway.com/charts
+   axway           https://repository.axway.com
    ```
 
 ## Validate the Amazon EC2 hybrid environment

--- a/content/en/docs/connect_manage_environ/mesh_management/build_hybrid_env.md
+++ b/content/en/docs/connect_manage_environ/mesh_management/build_hybrid_env.md
@@ -68,6 +68,7 @@ kops export kubecfg --name kubernetes-cluster.example.com --state s3://amazonaws
 
 ### Configure Helm on Amazon EC2
 
+The helm charts for the agents and download instructions can be found at https:/repository.axway.com/catalog.
 Install Helm on your cluster and add the Axway public repository to Helm:
 
 1. Verify the Helm version:
@@ -79,7 +80,7 @@ Install Helm on your cluster and add the Axway public repository to Helm:
 2. Add the Axway public Helm repository to your installation:
 
    ```bash
-   helm repo add axway https://repository.axway.com --username==<client-id> --password=<client_secret>
+   helm repo add axway https://helm.repository.axway.com --username==<client-id> --password=<client_secret>
    "axway" has been added to your repositories
    ```
 3. Verify that the Axway public repository has been added:
@@ -89,7 +90,7 @@ Install Helm on your cluster and add the Axway public repository to Helm:
    NAME            URL
    stable          https://kubernetes-charts.storage.googleapis.com
    local           http://127.0.0.1:8879/charts
-   axway           https://repository.axway.com
+   axway           https://helm.repository.axway.com
    ```
 
 ## Validate the Amazon EC2 hybrid environment

--- a/content/en/docs/connect_manage_environ/mesh_management/deploy-agents-with-helm.md
+++ b/content/en/docs/connect_manage_environ/mesh_management/deploy-agents-with-helm.md
@@ -384,7 +384,7 @@ There are several fields that must be updated in order to properly connect to Am
 ```bash
 helm repo add axway https://helm.repository.axway.com --username==<client-id> --password=<client_secret>
 helm repo update
-helm upgrade --install --namespace amplify-agents ampc-hybrid axway/ampc-hybrid -f hybrid-override.yaml
+helm upgrade --install --namespace amplify-agents ampc-hybrid axway/ampc-beano-helm-prod-ampc-hybrid -f hybrid-override.yaml
 ```
 
 ## Verify that the pods are running

--- a/content/en/docs/connect_manage_environ/mesh_management/deploy-agents-with-helm.md
+++ b/content/en/docs/connect_manage_environ/mesh_management/deploy-agents-with-helm.md
@@ -382,7 +382,7 @@ There are several fields that must be updated in order to properly connect to Am
 ## Deploy the agent
 
 ```bash
-helm repo add axway https://repository.axway.com --username==<client-id> --password=<client_secret>
+helm repo add axway https://helm.repository.axway.com --username==<client-id> --password=<client_secret>
 helm repo update
 helm upgrade --install --namespace amplify-agents ampc-hybrid axway/ampc-hybrid -f hybrid-override.yaml
 ```

--- a/content/en/docs/connect_manage_environ/mesh_management/deploy-agents-with-helm.md
+++ b/content/en/docs/connect_manage_environ/mesh_management/deploy-agents-with-helm.md
@@ -382,7 +382,7 @@ There are several fields that must be updated in order to properly connect to Am
 ## Deploy the agent
 
 ```bash
-helm repo add axway https://charts.axway.com/charts
+helm repo add axway https://repository.axway.com/charts
 helm repo update
 helm upgrade --install --namespace amplify-agents ampc-hybrid axway/ampc-hybrid -f hybrid-override.yaml
 ```

--- a/content/en/docs/connect_manage_environ/mesh_management/deploy-agents-with-helm.md
+++ b/content/en/docs/connect_manage_environ/mesh_management/deploy-agents-with-helm.md
@@ -382,7 +382,7 @@ There are several fields that must be updated in order to properly connect to Am
 ## Deploy the agent
 
 ```bash
-helm repo add axway https://repository.axway.com/charts
+helm repo add axway https://repository.axway.com --username==<client-id> --password=<client_secret>
 helm repo update
 helm upgrade --install --namespace amplify-agents ampc-hybrid axway/ampc-hybrid -f hybrid-override.yaml
 ```

--- a/content/en/docs/connect_manage_environ/mesh_management/deploy-your-agents-with-the-axway-cli.md
+++ b/content/en/docs/connect_manage_environ/mesh_management/deploy-your-agents-with-the-axway-cli.md
@@ -343,7 +343,7 @@ Once you save the `hybrid-override.yaml` file with the changes made above, run t
 ```bash
 helm repo add axway https://helm.repository.axway.com --username==<client-id> --password=<client_secret>
 helm repo update
-helm upgrade --install --namespace amplify-agents ampc-hybrid axway/ampc-hybrid -f hybrid-override.yaml
+helm upgrade --install --namespace amplify-agents ampc-hybrid axway/ampc-beano-helm-prod-ampc-hybrid -f hybrid-override.yaml
 ```
 
 {{< alert title="Note" color="primary" >}}By default, the Amplify Istio Discovery Agent polls every 60 seconds for the discovery resources. To change this, you must pass a helm override in the form of `--set da.poll.interval` or `--set da.pollInterval` accordingly with the desired agents.{{< /alert >}}
@@ -351,5 +351,5 @@ helm upgrade --install --namespace amplify-agents ampc-hybrid axway/ampc-hybrid 
 For example, if you want the Discovery Agent to poll every 10 seconds for the discovery resources, run the following command to install the agents:
 
 ```bash
-helm upgrade --install --namespace amplify-agents ampc-hybrid axway/ampc-hybrid -f hybrid-override.yaml --set da.pollInterval=10s
+helm upgrade --install --namespace amplify-agents ampc-hybrid axway/ampc-beano-helm-prod-ampc-hybrid -f hybrid-override.yaml --set da.pollInterval=10s
 ```

--- a/content/en/docs/connect_manage_environ/mesh_management/deploy-your-agents-with-the-axway-cli.md
+++ b/content/en/docs/connect_manage_environ/mesh_management/deploy-your-agents-with-the-axway-cli.md
@@ -341,7 +341,7 @@ where namespaces 1 through N is a list of all the namespaces on your cluster tha
 Once you save the `hybrid-override.yaml` file with the changes made above, run the following command to finish the installation of the agents:
 
 ```bash
-helm repo add axway https://repository.axway.com --username==<client-id> --password=<client_secret>
+helm repo add axway https://helm.repository.axway.com --username==<client-id> --password=<client_secret>
 helm repo update
 helm upgrade --install --namespace amplify-agents ampc-hybrid axway/ampc-hybrid -f hybrid-override.yaml
 ```

--- a/content/en/docs/connect_manage_environ/mesh_management/deploy-your-agents-with-the-axway-cli.md
+++ b/content/en/docs/connect_manage_environ/mesh_management/deploy-your-agents-with-the-axway-cli.md
@@ -341,7 +341,7 @@ where namespaces 1 through N is a list of all the namespaces on your cluster tha
 Once you save the `hybrid-override.yaml` file with the changes made above, run the following command to finish the installation of the agents:
 
 ```bash
-helm repo add axway https://repository.axway.com/charts
+helm repo add axway https://repository.axway.com --username==<client-id> --password=<client_secret>
 helm repo update
 helm upgrade --install --namespace amplify-agents ampc-hybrid axway/ampc-hybrid -f hybrid-override.yaml
 ```

--- a/content/en/docs/connect_manage_environ/mesh_management/deploy-your-agents-with-the-axway-cli.md
+++ b/content/en/docs/connect_manage_environ/mesh_management/deploy-your-agents-with-the-axway-cli.md
@@ -341,7 +341,7 @@ where namespaces 1 through N is a list of all the namespaces on your cluster tha
 Once you save the `hybrid-override.yaml` file with the changes made above, run the following command to finish the installation of the agents:
 
 ```bash
-helm repo add axway https://charts.axway.com/charts
+helm repo add axway https://repository.axway.com/charts
 helm repo update
 helm upgrade --install --namespace amplify-agents ampc-hybrid axway/ampc-hybrid -f hybrid-override.yaml
 ```


### PR DESCRIPTION
Thank you for your contribution to the Amplify-Central repo.

## Describe the changes

Due to security risks, change https://charts.axway.com to https://repository.axway.com

## Deploy preview link

Please add the deploy preview link to the **specific page** that you've changed.

## Checklist for contributors

Before submitting this PR:

* Verify that all status checks have passed
* For more information on the Markdown linter rules, see [DavidAnson/markdownlint](https://github.com/DavidAnson/markdownlint)
* For first-time contributors, ensure that you have signed the [Axway CLA](https://cla.axway.com/)
