### PR TITLE
APIGOV-28139 added audit log variables

### DIFF
--- a/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
@@ -208,6 +208,23 @@ APIMANAGER_CUSTOM_OAUTHEXT_CLIENTID_LABEL="Azure AD Client Id"
 | APIGATEWAY_SSL_MINVERSION                     | String value for the minimum SSL / TLS version that is acceptable. If zero, empty TLS 1.0 is taken as the minimum. Allowed values are: TLS1.0, TLS1.1, TLS1.2, TLS1.3.                                                                                                                                                                     |
 | APIGATEWAY_SSL_NEXTPROTOS                     | An array of strings. It is a list of supported application level protocols, in order of preference, based on the ALPN protocol list. Allowed values are: h2, http/1.0, http/1.1, h2c.                                                                                                                                                      |
 
+#### Audit log variables
+
+For a full explanation on how to use the Traceability agent audit logs see [Traceability Agent audit logs](/docs/connect_manage_environ/connected_agent_common_reference/traceability_audit_logs).
+
+| Environment Variable            | Description                                                                                   |
+| ------------------------------- | --------------------------------------------------------------------------------------------- |
+| LOG_METRICFILE_ENABLED          | Enable or disable the metric audit log (default: `true`)                                      |
+| LOG_METRICFILE_NAME             | The name of the metric log file that will be created (default: `metric.log`)                  |
+| LOG_METRICFILE_KEEPFILES        | The maximum number of metric audit log files to keep (default: `7`)                           |
+| LOG_METRICFILE_ROTATEEVERYBYTES | The maximum size (bytes) a metric audit log can grow to (default: `10485760`=`10 megabytes`)  |
+| LOG_METRICFILE_CLEANBACKUPS     | The max age of a metric audit log backup file, in days (default: `0` unlimited)               |
+| LOG_USAGEFILE_ENABLED           | Enable or disable the usage audit log (default: `true`)                                       |
+| LOG_USAGEFILE_NAME              | The name of the usage log file that will be created (default: `usagefile.log`)                |
+| LOG_USAGEFILE_KEEPFILES         | The maximum number of usage audit log files to keep (default: `7`)                            |
+| LOG_USAGEFILE_ROTATEEVERYBYTES  | The maximum size (bytes) a usage audit log can grow to (default: `10485760`=`10 megabytes`)   |
+| LOG_USAGEFILE_CLEANBACKUPS      | The max age of a usage audit log backup file, in days (default: `365` days)                   |
+
 {{< alert title="Note" color="primary" >}}The following variables are available but not recommended for production purposes.{{< /alert >}}
 
 | Variable name           | Description                                                                                                                          |

--- a/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
@@ -212,19 +212,6 @@ APIMANAGER_CUSTOM_OAUTHEXT_CLIENTID_LABEL="Azure AD Client Id"
 
 For a full explanation on how to use the Traceability agent audit logs see [Traceability Agent audit logs](/docs/connect_manage_environ/connected_agent_common_reference/traceability_audit_logs).
 
-| Environment Variable            | Description                                                                                   |
-| ------------------------------- | --------------------------------------------------------------------------------------------- |
-| LOG_METRICFILE_ENABLED          | Enable or disable the metric audit log (default: `true`)                                      |
-| LOG_METRICFILE_NAME             | The name of the metric log file that will be created (default: `metric.log`)                  |
-| LOG_METRICFILE_KEEPFILES        | The maximum number of metric audit log files to keep (default: `7`)                           |
-| LOG_METRICFILE_ROTATEEVERYBYTES | The maximum size (bytes) a metric audit log can grow to (default: `10485760`=`10 megabytes`)  |
-| LOG_METRICFILE_CLEANBACKUPS     | The max age of a metric audit log backup file, in days (default: `0` unlimited)               |
-| LOG_USAGEFILE_ENABLED           | Enable or disable the usage audit log (default: `true`)                                       |
-| LOG_USAGEFILE_NAME              | The name of the usage log file that will be created (default: `usagefile.log`)                |
-| LOG_USAGEFILE_KEEPFILES         | The maximum number of usage audit log files to keep (default: `7`)                            |
-| LOG_USAGEFILE_ROTATEEVERYBYTES  | The maximum size (bytes) a usage audit log can grow to (default: `10485760`=`10 megabytes`)   |
-| LOG_USAGEFILE_CLEANBACKUPS      | The max age of a usage audit log backup file, in days (default: `365` days)                   |
-
 {{< alert title="Note" color="primary" >}}The following variables are available but not recommended for production purposes.{{< /alert >}}
 
 | Variable name           | Description                                                                                                                          |

--- a/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
@@ -210,7 +210,7 @@ APIMANAGER_CUSTOM_OAUTHEXT_CLIENTID_LABEL="Azure AD Client Id"
 
 #### Audit log variables
 
-For a full explanation on how to use the Traceability agent audit logs see [Traceability Agent audit logs](/docs/connect_manage_environ/connected_agent_common_reference/traceability_audit_logs).
+For a full explanation on how to use the Traceability Agent audit logs see [Traceability Agent audit logs](/docs/connect_manage_environ/connected_agent_common_reference/traceability_audit_logs).
 
 {{< alert title="Note" color="primary" >}}The following variables are available but not recommended for production purposes.{{< /alert >}}
 

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/agent-variables.md
@@ -149,7 +149,7 @@ All of the variables in this list may be repeated for each IdP to be used. Each 
 | TRACEABILITY_SAMPLING_REPORTALLERRORS          | When true, all API transactions that have an http error code will be sent to Amplify (default value: `true`).                                                                                                                                                                                                                  |
 | TRACEABILITY_WORKER                            | The number of workers collecting events and sending them to Enterprise Marketplace (default value: `1`).                                                                                                                                                                                                                        |
 
-## Audit log variables
+#### Audit log variables
 
 For a full explanation on how to use the Traceability agent audit logs see [Traceability Agent audit logs](/docs/connect_manage_environ/connected_agent_common_reference/traceability_audit_logs).
 
@@ -168,7 +168,7 @@ For a full explanation on how to use the Traceability agent audit logs see [Trac
 
 With the default settings, the Traceability Agent will keep a maximum of `7` files, each a total of `10485760` bytes.
 
-# Additional Axway API Manager Traceability Agent audit log
+#### Additional Axway API Manager Traceability Agent audit log
 
 The Traceability Agent that connects to Axway API Manager includes an additional transaction audit log to track the correlation IDs of each transaction the agent has seen and recorded. The following table lists the environment variables that are available to configure the transaction audit logs.
 

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/agent-variables.md
@@ -6,18 +6,18 @@ weight: 40
 ---
 The variables common to all agents are described here in more detail.
 
-- [Agent Variables](#agent-variables)
-  - [Common to Discovery and Traceability](#common-to-discovery-and-traceability)
-    - [Status endpoint variables](#status-endpoint-variables)
-    - [Logging variables](#logging-variables)
-    - [Audit log variables](#audit-log-variables)
-  - [Discovery agent only variables](#discovery-agent-only-variables)
-    - [IdP configuration variables](#idp-configuration-variables)
-  - [Traceability agent only variables](#traceability-agent-only-variables)
-- [CENTRAL\_APISERVICEREVISIONPATTERN](#central_apiservicerevisionpattern)
-  - [Default pattern](#default-pattern)
-  - [Available variables](#available-variables)
-  - [Date Formats](#date-formats)
+* [Agent Variables](#agent-variables)
+    * [Common to Discovery and Traceability](#common-to-discovery-and-traceability)
+        * [Status endpoint variables](#status-endpoint-variables)
+        * [Logging variables](#logging-variables)
+    * [Discovery agent only variables](#discovery-agent-only-variables)
+        * [IdP configuration variables](#idp-configuration-variables)
+    * [Traceability agent only variables](#traceability-agent-only-variables)
+        * [Audit log variables](#audit-log-variables)
+* [CENTRAL\_APISERVICEREVISIONPATTERN](#central_apiservicerevisionpattern)
+    * [Default pattern](#default-pattern)
+    * [Available variables](#available-variables)
+    * [Date Formats](#date-formats)
 
 ## Agent Variables
 
@@ -74,23 +74,6 @@ The variables common to all agents are described here in more detail.
 | LOG_OUTPUT                | The output for the log lines (stdout, file, both). When set to `both` for the Traceability Agent, only the file output will appear.                                                       |
 
 {{< alert title="Note" color="primary" >}}It is recommended to set up logging in the agent configuration file to keep the logs separated for each agent.{{< /alert >}}
-
-#### Audit log variables
-
-For a full explanation on how to use the Traceability agent audit logs see [Traceability Agent audit logs](/docs/connect_manage_environ/connected_agent_common_reference/traceability_audit_logs).
-
-| Environment Variable            | Description                                                                                   |
-| ------------------------------- | --------------------------------------------------------------------------------------------- |
-| LOG_METRICFILE_ENABLED          | Enable or disable the metric audit log (default: `true`)                                      |
-| LOG_METRICFILE_NAME             | The name of the metric log file that will be created (default: `metric.log`)                  |
-| LOG_METRICFILE_KEEPFILES        | The maximum number of metric audit log files to keep (default: `7`)                           |
-| LOG_METRICFILE_ROTATEEVERYBYTES | The maximum size (bytes) a metric audit log can grow to (default: `10485760`=`10 megabytes`)  |
-| LOG_METRICFILE_CLEANBACKUPS     | The max age of a metric audit log backup file, in days (default: `0` unlimited)               |
-| LOG_USAGEFILE_ENABLED           | Enable or disable the usage audit log (default: `true`)                                       |
-| LOG_USAGEFILE_NAME              | The name of the usage log file that will be created (default: `usagefile.log`)                |
-| LOG_USAGEFILE_KEEPFILES         | The maximum number of usage audit log files to keep (default: `7`)                            |
-| LOG_USAGEFILE_ROTATEEVERYBYTES  | The maximum size (bytes) a usage audit log can grow to (default: `10485760`=`10 megabytes`)   |
-| LOG_USAGEFILE_CLEANBACKUPS      | The max age of a usage audit log backup file, in days (default: `365` days)                   |
 
 ### Discovery agent only variables
 
@@ -165,6 +148,38 @@ All of the variables in this list may be repeated for each IdP to be used. Each 
 | TRACEABILITY_SAMPLING_PER_API                  | When true, the percentage of API transactions sent will be based on each API ID in the transaction (default value: `true`).                                                                                                                                                                                                     |
 | TRACEABILITY_SAMPLING_REPORTALLERRORS          | When true, all API transactions that have an http error code will be sent to Amplify (default value: `true`).                                                                                                                                                                                                                  |
 | TRACEABILITY_WORKER                            | The number of workers collecting events and sending them to Enterprise Marketplace (default value: `1`).                                                                                                                                                                                                                        |
+
+## Audit log variables
+
+For a full explanation on how to use the Traceability agent audit logs see [Traceability Agent audit logs](/docs/connect_manage_environ/connected_agent_common_reference/traceability_audit_logs).
+
+| Environment Variable            | Description                                                                                   |
+| ------------------------------- | --------------------------------------------------------------------------------------------- |
+| LOG_METRICFILE_ENABLED          | Enable or disable the metric audit log (default: `true`)                                      |
+| LOG_METRICFILE_NAME             | The name of the metric log file that will be created (default: `metric.log`)                  |
+| LOG_METRICFILE_KEEPFILES        | The maximum number of metric audit log files to keep (default: `7`)                           |
+| LOG_METRICFILE_ROTATEEVERYBYTES | The maximum size (bytes) a metric audit log can grow to (default: `10485760`=`10 megabytes`)  |
+| LOG_METRICFILE_CLEANBACKUPS     | The max age of a metric audit log backup file, in days (default: `0` unlimited)               |
+| LOG_USAGEFILE_ENABLED           | Enable or disable the usage audit log (default: `true`)                                       |
+| LOG_USAGEFILE_NAME              | The name of the usage log file that will be created (default: `usagefile.log`)                |
+| LOG_USAGEFILE_KEEPFILES         | The maximum number of usage audit log files to keep (default: `7`)                            |
+| LOG_USAGEFILE_ROTATEEVERYBYTES  | The maximum size (bytes) a usage audit log can grow to (default: `10485760`=`10 megabytes`)   |
+| LOG_USAGEFILE_CLEANBACKUPS      | The max age of a usage audit log backup file, in days (default: `365` days)                   |
+
+With the default settings, the Traceability Agent will keep a maximum of `7` files, each a total of `10485760` bytes.
+
+# Additional Axway API Manager Traceability Agent audit log
+
+The Traceability Agent that connects to Axway API Manager includes an additional transaction audit log to track the correlation IDs of each transaction the agent has seen and recorded. The following table lists the environment variables that are available to configure the transaction audit logs.
+
+| Environment Variable             | Description                                                                                            |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| LOG_TRANSACTION_ENABLED          | Enable or disable the transaction audit log (default: `true`)                                          |
+| LOG_TRANSACTION_NAME             | The name of the transaction log file that will be created (default: `transaction.log`)                 |
+| LOG_TRANSACTION_KEEPFILES        | The maximum number of transaction audit log files to keep (default: `7`)                               |
+| LOG_TRANSACTION_ROTATEEVERYBYTES | The maximum size, (bytes) a transaction audit log can grow to (default: `10485760`=`10 megabytes`) |
+| LOG_TRANSACTION_CLEANBACKUPS     | The max age of a transaction audit log backup file, in days (default: `0` unlimited)                   |
+
 
 ## CENTRAL_APISERVICEREVISIONPATTERN
 

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/agent-variables.md
@@ -6,18 +6,19 @@ weight: 40
 ---
 The variables common to all agents are described here in more detail.
 
-* [Agent Variables](#agent-variables)
-    * [Common to Discovery and Traceability](#common-to-discovery-and-traceability)
-        * [Status endpoint variables](#status-endpoint-variables)
-        * [Logging variables](#logging-variables)
-        * [Audit log variables](#audit-log-variables)
-    * [Discovery agent only variables](#discovery-agent-only-variables)
-        * [IdP configuration variables](#idp-configuration-variables)
-    * [Traceability agent only variables](#traceability-agent-only-variables)
-* [CENTRAL\_APISERVICEREVISIONPATTERN](#central_apiservicerevisionpattern)
-    * [Default pattern](#default-pattern)
-    * [Available variables](#available-variables)
-    * [Date Formats](#date-formats)
+- [Agent Variables](#agent-variables)
+  - [Common to Discovery and Traceability](#common-to-discovery-and-traceability)
+    - [Status endpoint variables](#status-endpoint-variables)
+    - [Logging variables](#logging-variables)
+    - [Audit log variables](#audit-log-variables)
+  - [Additional Axway API Manager Traceability Agent audit log](#additional-axway-api-manager-traceability-agent-audit-log)
+  - [Discovery agent only variables](#discovery-agent-only-variables)
+    - [IdP configuration variables](#idp-configuration-variables)
+  - [Traceability agent only variables](#traceability-agent-only-variables)
+- [CENTRAL\_APISERVICEREVISIONPATTERN](#central_apiservicerevisionpattern)
+  - [Default pattern](#default-pattern)
+  - [Available variables](#available-variables)
+  - [Date Formats](#date-formats)
 
 ## Agent Variables
 
@@ -91,6 +92,18 @@ For a full explanation on how to use the Traceability agent audit logs see [Trac
 | LOG_USAGEFILE_KEEPFILES         | The maximum number of usage audit log files to keep (default: `7`)                            |
 | LOG_USAGEFILE_ROTATEEVERYBYTES  | The maximum size (bytes) a usage audit log can grow to (default: `10485760`=`10 megabytes`)   |
 | LOG_USAGEFILE_CLEANBACKUPS      | The max age of a usage audit log backup file, in days (default: `365` days)                   |
+
+### Additional Axway API Manager Traceability Agent audit log
+
+The Traceability Agent that connects to Axway API Manager includes an additional transaction audit log to track the correlation IDs of each transaction the agent has seen and recorded. The following table lists the environment variables that are available to configure the transaction audit logs.
+
+| Environment Variable             | Description                                                                                            |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| LOG_TRANSACTION_ENABLED          | Enable or disable the transaction audit log (default: `true`)                                          |
+| LOG_TRANSACTION_NAME             | The name of the transaction log file that will be created (default: `transaction.log`)                 |
+| LOG_TRANSACTION_KEEPFILES        | The maximum number of transaction audit log files to keep (default: `7`)                               |
+| LOG_TRANSACTION_ROTATEEVERYBYTES | The maximum size, (bytes) a transaction audit log can grow to (default: `10485760`=`10 megabytes`) |
+| LOG_TRANSACTION_CLEANBACKUPS     | The max age of a transaction audit log backup file, in days (default: `0` unlimited)                   |
 
 ### Discovery agent only variables
 

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/agent-variables.md
@@ -11,7 +11,6 @@ The variables common to all agents are described here in more detail.
     - [Status endpoint variables](#status-endpoint-variables)
     - [Logging variables](#logging-variables)
     - [Audit log variables](#audit-log-variables)
-  - [Additional Axway API Manager Traceability Agent audit log](#additional-axway-api-manager-traceability-agent-audit-log)
   - [Discovery agent only variables](#discovery-agent-only-variables)
     - [IdP configuration variables](#idp-configuration-variables)
   - [Traceability agent only variables](#traceability-agent-only-variables)
@@ -92,18 +91,6 @@ For a full explanation on how to use the Traceability agent audit logs see [Trac
 | LOG_USAGEFILE_KEEPFILES         | The maximum number of usage audit log files to keep (default: `7`)                            |
 | LOG_USAGEFILE_ROTATEEVERYBYTES  | The maximum size (bytes) a usage audit log can grow to (default: `10485760`=`10 megabytes`)   |
 | LOG_USAGEFILE_CLEANBACKUPS      | The max age of a usage audit log backup file, in days (default: `365` days)                   |
-
-### Additional Axway API Manager Traceability Agent audit log
-
-The Traceability Agent that connects to Axway API Manager includes an additional transaction audit log to track the correlation IDs of each transaction the agent has seen and recorded. The following table lists the environment variables that are available to configure the transaction audit logs.
-
-| Environment Variable             | Description                                                                                            |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| LOG_TRANSACTION_ENABLED          | Enable or disable the transaction audit log (default: `true`)                                          |
-| LOG_TRANSACTION_NAME             | The name of the transaction log file that will be created (default: `transaction.log`)                 |
-| LOG_TRANSACTION_KEEPFILES        | The maximum number of transaction audit log files to keep (default: `7`)                               |
-| LOG_TRANSACTION_ROTATEEVERYBYTES | The maximum size, (bytes) a transaction audit log can grow to (default: `10485760`=`10 megabytes`) |
-| LOG_TRANSACTION_CLEANBACKUPS     | The max age of a transaction audit log backup file, in days (default: `0` unlimited)                   |
 
 ### Discovery agent only variables
 

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/agent-variables.md
@@ -75,7 +75,7 @@ The variables common to all agents are described here in more detail.
 
 {{< alert title="Note" color="primary" >}}It is recommended to set up logging in the agent configuration file to keep the logs separated for each agent.{{< /alert >}}
 
-### Discovery agent only variables
+### Discovery Agent only variables
 
 | Variable name                    | Description                                                                                                                                 |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -118,7 +118,7 @@ All of the variables in this list may be repeated for each IdP to be used. Each 
 
 {{< alert title="Note" color="primary" >}}Not all agents support these IdP settings.{{< /alert >}}
 
-### Traceability agent only variables
+### Traceability Agent only variables
 
 | Variable name                                  | Description                                                                                                                                                                                                                                                                                                                     |
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -151,20 +151,20 @@ All of the variables in this list may be repeated for each IdP to be used. Each 
 
 #### Audit log variables
 
-For a full explanation on how to use the Traceability agent audit logs see [Traceability Agent audit logs](/docs/connect_manage_environ/connected_agent_common_reference/traceability_audit_logs).
+For a full explanation on how to use the Traceability Agent audit logs see [Traceability Agent audit logs](/docs/connect_manage_environ/connected_agent_common_reference/traceability_audit_logs).
 
 | Environment Variable            | Description                                                                                   |
 | ------------------------------- | --------------------------------------------------------------------------------------------- |
-| LOG_METRICFILE_ENABLED          | Enable or disable the metric audit log (default: `true`)                                      |
-| LOG_METRICFILE_NAME             | The name of the metric log file that will be created (default: `metric.log`)                  |
-| LOG_METRICFILE_KEEPFILES        | The maximum number of metric audit log files to keep (default: `7`)                           |
-| LOG_METRICFILE_ROTATEEVERYBYTES | The maximum size (bytes) a metric audit log can grow to (default: `10485760`=`10 megabytes`)  |
-| LOG_METRICFILE_CLEANBACKUPS     | The max age of a metric audit log backup file, in days (default: `0` unlimited)               |
-| LOG_USAGEFILE_ENABLED           | Enable or disable the usage audit log (default: `true`)                                       |
-| LOG_USAGEFILE_NAME              | The name of the usage log file that will be created (default: `usagefile.log`)                |
-| LOG_USAGEFILE_KEEPFILES         | The maximum number of usage audit log files to keep (default: `7`)                            |
-| LOG_USAGEFILE_ROTATEEVERYBYTES  | The maximum size (bytes) a usage audit log can grow to (default: `10485760`=`10 megabytes`)   |
-| LOG_USAGEFILE_CLEANBACKUPS      | The max age of a usage audit log backup file, in days (default: `365` days)                   |
+| LOG_METRICFILE_ENABLED          | Enable or disable the metric audit log (default: `true`).                                      |
+| LOG_METRICFILE_NAME             | The name of the metric log file that will be created (default: `metric.log`).                  |
+| LOG_METRICFILE_KEEPFILES        | The maximum number of metric audit log files to keep (default: `7`).                           |
+| LOG_METRICFILE_ROTATEEVERYBYTES | The maximum size (bytes) a metric audit log can grow to (default: `10485760`=`10 megabytes`).  |
+| LOG_METRICFILE_CLEANBACKUPS     | The maximum age of a metric audit log backup file, in days (default: `0` unlimited).               |
+| LOG_USAGEFILE_ENABLED           | Enable or disable the usage audit log (default: `true`).                                       |
+| LOG_USAGEFILE_NAME              | The name of the usage log file that will be created (default: `usagefile.log`).                |
+| LOG_USAGEFILE_KEEPFILES         | The maximum number of usage audit log files to keep (default: `7`).                            |
+| LOG_USAGEFILE_ROTATEEVERYBYTES  | The maximum size (bytes) a usage audit log can grow to (default: `10485760`=`10 megabytes`).   |
+| LOG_USAGEFILE_CLEANBACKUPS      | The maximum age of a usage audit log backup file, in days (default: `365` days).                   |
 
 With the default settings, the Traceability Agent will keep a maximum of `7` files, each a total of `10485760` bytes.
 
@@ -174,11 +174,11 @@ The Traceability Agent that connects to Axway API Manager includes an additional
 
 | Environment Variable             | Description                                                                                            |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| LOG_TRANSACTION_ENABLED          | Enable or disable the transaction audit log (default: `true`)                                          |
-| LOG_TRANSACTION_NAME             | The name of the transaction log file that will be created (default: `transaction.log`)                 |
-| LOG_TRANSACTION_KEEPFILES        | The maximum number of transaction audit log files to keep (default: `7`)                               |
-| LOG_TRANSACTION_ROTATEEVERYBYTES | The maximum size, (bytes) a transaction audit log can grow to (default: `10485760`=`10 megabytes`) |
-| LOG_TRANSACTION_CLEANBACKUPS     | The max age of a transaction audit log backup file, in days (default: `0` unlimited)                   |
+| LOG_TRANSACTION_ENABLED          | Enable or disable the transaction audit log (default: `true`).                                          |
+| LOG_TRANSACTION_NAME             | The name of the transaction log file that will be created (default: `transaction.log`).                 |
+| LOG_TRANSACTION_KEEPFILES        | The maximum number of transaction audit log files to keep (default: `7`).                               |
+| LOG_TRANSACTION_ROTATEEVERYBYTES | The maximum size, (bytes) a transaction audit log can grow to (default: `10485760`=`10 megabytes`). |
+| LOG_TRANSACTION_CLEANBACKUPS     | The maximum age of a transaction audit log backup file, in days (default: `0` unlimited).                   |
 
 ## CENTRAL_APISERVICEREVISIONPATTERN
 

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/agent-variables.md
@@ -180,7 +180,6 @@ The Traceability Agent that connects to Axway API Manager includes an additional
 | LOG_TRANSACTION_ROTATEEVERYBYTES | The maximum size, (bytes) a transaction audit log can grow to (default: `10485760`=`10 megabytes`) |
 | LOG_TRANSACTION_CLEANBACKUPS     | The max age of a transaction audit log backup file, in days (default: `0` unlimited)                   |
 
-
 ## CENTRAL_APISERVICEREVISIONPATTERN
 
 This variable sets the pattern used when creating API service revisions on Enterprise Marketplace.  The default pattern is `{{.APIServiceName}}{{if ne .Stage ""}} ({{.StageLabel}}: {{.Stage}}){{end}} - {{.Date:YYYY/MM/DD}} - r {{.Revision}}`.


### PR DESCRIPTION
Thank you for your contribution to the Amplify-Central repo.

## Describe the changes

Updated the agent configuration page to contain the audit log variables

## Deploy preview link

[Agent Configuration](http://pr-478.amplify-central.opendocs-builder.pcloud.axway.int/docs/connect_manage_environ/connect_api_manager/agent-variables/index.html)

## Checklist for contributors

Before submitting this PR:

* Verify that all status checks have passed
* For more information on the Markdown linter rules, see [DavidAnson/markdownlint](https://github.com/DavidAnson/markdownlint)
* For first-time contributors, ensure that you have signed the [Axway CLA](https://cla.axway.com/)
