### PR TITLE
APIGOV-29117 - add docs for handling externally managed credentials

### DIFF
--- a/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
@@ -121,11 +121,14 @@ When a Front End Proxy is secured by invoking a policy, the agent will not know 
 | APIMANAGER_INVOKEPOLICY_DEFAULTDESCRIPTION     | When a proxy is secured by a policy, this description is added to the Access Request Definition if no description text is found in API Manager (default: `Contact your provider about authenticating to this API`). |
 | APIMANAGER_INVOKEPOLICY_TITLE                  | When a proxy is secured by a policy, this title is added to the Access Request Definition (default: `Authentication Details`).                                                                                      |
 | APIMANAGER_INVOKEPOLICY_MAPPING_POLICYNAME     | The policy name that should be mapped to a specific credential type.                                                                                                                                                |
-| APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPE | The credential type to map for the policy name specified. Options are APIKey, Basic, Oauth and any value set in the `AGENTFEATURES_IDP_NAME` variables.                                                             |
+| APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPE | The credential type to map for the policy name specified. Options are APIKey, Basic, Oauth, external and any value set in the `AGENTFEATURES_IDP_NAME` variables.                                                             |
+| APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPENAME | The credential request definition names to map for the policy name specified when using the external credential type. |
 
 The `APIMANAGER_INVOKEPOLICY_DEFAULTDESCRIPTION` and `APIMANAGER_INVOKEPOLICY_TITLE` settings are used when the Discovery Agent cannot find a mapping to apply. These values are set in the Access Request to give the end consumer a hint on authenticating to the API.
 
 The `APIMANAGER_INVOKEPOLICY_MAPPING_POLICYNAME` and `APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPE` settings may be repeated for every mapping that is required. For each new mapping being added increase the index at the end of the variable name.
+
+The `APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPENAME` setting is used when the agent should not handle a CRD which is managed externally.
 
 Here is an example of multiple invoke policy mappings. Notice how the index number was incremented for each successive mapping.
 
@@ -158,7 +161,17 @@ AGENTFEATURES_IDP_AUTH_TYPE_1="accessToken"
 AGENTFEATURES_IDP_AUTH_ACCESSTOKEN_1="okta-admin-api-access-token-xxxxxxxxx"
 ```
 
-{{< alert title="Note" color="primary" >}}This setup will only enable the ability to request a credential in Amplify Marketplace. It will not update the specification to include the IDP definition.{{< /alert >}}
+##### Invoke policy mapping to externally managed credential request definition example
+
+An invoke policy mapping may reference an externally managed credential request definition. Below is a sample of the environment variable setup to handle this mapping.
+
+Given the configuration below, an agent will ignore events which trigger the credential provisioning because it is assumed to be handled externally. The credential type for this must be set as external.
+
+```shell
+APIMANAGER_INVOKEPOLICY_MAPPING_POLICYNAME_1=ExternalPolicy
+APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPE_1=external
+APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPENAME_1=external-crd-name
+```
 
 #### Custom OAuth External policy handling
 

--- a/content/en/docs/connect_manage_environ/connect_api_manager/gateway-administation.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/gateway-administation.md
@@ -201,11 +201,12 @@ When virtualizing a REST API in API Manager, you can configure inbound security 
 
 {{< alert title="Note" color="primary" >}}The agent will handle the mapped authentication type as if the proxy were configured to use it. The agent will not validate that the policy uses the mapped authentication type. That responsibility belongs to the policy creator.{{< /alert >}}
 
-To map a policy to an authentication type (OAuth, Basic Auth, API Key), use the following environment variables, incrementing the index as needed:
+To map a policy to an authentication type (OAuth, Basic Auth, API Key, external), use the following environment variables, incrementing the index as needed:
 
 * `APIMANAGER_INVOKEPOLICY_MAPPING_POLICYNAME_1=Invoke API Key` where *Invoke API Key* is the name of the policy attached to the proxy.
 * `APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPE_1=APIKey` where *APIKey* is the authentication type that the agent should handle the proxy as. Options are APIKey, Basic, OAuth.
 * Additional mappings should have env vars, such as `APIMANAGER_INVOKEPOLICY_MAPPING_POLICYNAME_2`, `APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPE_2`, etc.
+* `APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPENAME_1=external-crd-name` can be used for setting the externally managed credentials if `APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPE_1=external` is also set.
 
 In cases where a policy is used but not mapped to a specific authentication type, the agent will create an Access Request Definition (ARD) that will display the authentication details and the description of the policy being used. If a description cannot be found, the agent will use the value defined by the `APIMANAGER_INVOKEPOLICY_DEFAULTDESCRIPTION` environment variable if:
 


### PR DESCRIPTION
## Describe the changes

Adds explanation on how to setup env vars for the the externally managed credentials, which the agent should ignore during provisioning.
