### PR TITLE
Consumption unit

### DIFF
--- a/content/en/docs/get_actionable_insights/business_insights.md
+++ b/content/en/docs/get_actionable_insights/business_insights.md
@@ -96,7 +96,7 @@ Click **Applications** to see metrics and charts about the performance of API as
 
   ![Example of App usage](/Images/central/app_usage.png)
 
-You can filter by consuming team, application, product, service, and a pre-configured timeframe or customize your own.
+You can filter by consuming team, application, product, service, consumption units and a pre-configured timeframe or customize your own.
 
 Click an individual item to see the products with the service name and number of transactions per service.
 
@@ -108,7 +108,7 @@ Click **Subscriptions** to see a list of the consumer team with their subscripti
 
 ![Example of Subscriptions](/Images/central/subscriptions.png)
 
-You can filter by consuming team, product, resource (API), application, subscription, and time range in three month increments (last 3 months, 4 to 6 months, 7 to 9 months, and 10 to 12 months).
+You can filter by consuming team, product, resource (API), application, subscription, consumption units and time range in three month increments (last 3 months, 4 to 6 months, 7 to 9 months, and 10 to 12 months).
 
 Click the **Actions (..) menu** to download the table data.
 

--- a/content/en/docs/manage_product_foundry/manage_consumption_units.md
+++ b/content/en/docs/manage_product_foundry/manage_consumption_units.md
@@ -87,3 +87,11 @@ You will need 2 things:
 The language can be accessed using the List view ellipsis menu **Translate**. This will open the *translation details* screen where you can set the Default Language.
 
 Once a default language is selection, you can add the other needed languages by using the translation icon. This will open the translation panel where you can add the translated name and description.
+
+## Report a consumption unit
+
+TBD
+
+## Visualize consumption unit in Business or Consumer Insights
+
+TBD

--- a/content/en/docs/manage_product_foundry/manage_consumption_units.md
+++ b/content/en/docs/manage_product_foundry/manage_consumption_units.md
@@ -94,11 +94,14 @@ To report custom unit, a service (Custom Unit Service) will have to be implement
 
 ### Flow
 
-Once a consumer request an access to an API via a Marketplace application, an event is generated. This event can be listen so that anyone can react on it.
+Once a consumer request an access to an API via a Marketplace application, an event is generated. This event can be listen so that anyone can react on it. Typically our Discovery Agent listen to that event to apply the quota on the Gateway when creating the application/api link.
 
-When an API call is made, the Gateway logs the information in eventlog or openlog. Traceability agent is listening these logs to create the corresponding metrics and send those metrics to Amplify Platform.
+When an API call is made, the Gateway logs the information in eventlog or openlog. Traceability agent is listening these logs to create the corresponding transaction metrics and send those metrics to Amplify Platform.
 
-The Custom Unit Service will have to listen to these too in order to compute the number of unit used and transfer this to the Traceability Agent so that then it reports it to the AMplify Platform.
+Regarding the custom consumption unit, the Custom Unit Service will have to:
+
+* listen to the provisioning quota so that it can be aware of the application/api linking and possibly add some quota enforcement on the Gateway
+* compute the number of unit used for a specific api under the application umbrella and transfer this information to the Traceability Agent to report it to the Amplify Platform.
 
 ### Service implementation
 

--- a/content/en/docs/manage_product_foundry/manage_consumption_units.md
+++ b/content/en/docs/manage_product_foundry/manage_consumption_units.md
@@ -30,7 +30,7 @@ View the following information for all consumption units:
 * Plans - number of plan that are currently using that unit.
 * Modified date - last know modification date
 
-The Ellipsis menu allows to:
+The ellipsis menu allows to:
 
 * Edit - for [updating](#edit-a-consumption-unit) the consumption unit
 * Translate - for [translating](#consumption-unit-multi-language) the title and description of the consumption unit
@@ -61,7 +61,7 @@ Catalog Manager or Central Administrator can create consumption unit.
 
 ## Delete a consumption unit
 
-Catalog Manager or Central Administrator can create consumption unit.
+Catalog Manager or Central Administrator can delete consumption unit.
 
 Delete is only allowed if the consumption unit is not used in any plan quota.
 
@@ -90,8 +90,26 @@ Once a default language is selection, you can add the other needed languages by 
 
 ## Report a consumption unit
 
-TBD
+To report custom unit, a service (Custom Unit Service) will have to be implemented in order to compute the information the Traceability Agent will send back to Amplify Platform.
+
+### Flow
+
+Once a consumer request an access to an API via a Marketplace application, an event is generated. This event can be listen so that anyone can react on it.
+
+When an API call is made, the Gateway logs the information in eventlog or openlog. Traceability agent is listening these logs to create the corresponding metrics and send those metrics to Amplify Platform.
+
+The Custom Unit Service will have to listen to these too in order to compute the number of unit used and transfer this to the Traceability Agent so that then it reports it to the AMplify Platform.
+
+### Service implementation
+
+This service will be accessed by the Discovery Agent to inform when a quota having custom unit is provisioned.
+
+This service will send information related to custom unit consumption to the Traceability Agent so that the Traceability Agent can report the metrics to the Amplify Platform.
+
+Refer to [Use Custom Units with Discovery and Traceability Agents](/docs/connect_manage_environ/connected_agent_common_reference/custom-unit-metrics) for more information about its implementation.
 
 ## Visualize consumption unit in Business or Consumer Insights
 
-TBD
+An additional filter has been added to the Business/Consumer Insights Applications and Subscriptions screens to be able to filter using the consumption units.
+
+The filter contains the list of all available consumption units. Once a consumption unit is selected, the corresponding data if any are displayed.

--- a/content/en/docs/manage_product_foundry/manage_consumption_units.md
+++ b/content/en/docs/manage_product_foundry/manage_consumption_units.md
@@ -1,0 +1,89 @@
+---
+title: Manage consumption units
+linkTitle: Manage consumption units
+weight: 75
+---
+
+MAnage the consumption units you want to monetize.
+
+## Objectives
+
+Learn how to create consumption unit.
+
+## Concepts
+
+A consumption unit defines the billable units. For example: Transactions, Seats, Messages. Used with the quotas to describe the pricing and how many units a consumer is entitled to use.
+
+By default the product comes with the **Transaction** consumption unit. This allow to bill consumer based on the number of request they are executing.
+
+## View a consumption unit
+
+Catalog Manager or Central Administrator can view consumption unit.
+
+1. Navigate to *Catalog > Product Foundry* > **Consumption Units**. This open the consumption unit page.
+
+View the following information for all consumption units:
+
+* Unit name - The name displayed to consumer in the plan quota definition.
+* Logical Name - The technical identifier of the consumption unit.
+* Description - The consumption unit description to help understand its purpose.
+* Plans - number of plan that are currently using that unit.
+* Modified date - last know modification date
+
+The Ellipsis menu allows to:
+
+* Edit - for [updating](#edit-a-consumption-unit) the consumption unit
+* Translate - for [translating](#consumption-unit-multi-language) the title and description of the consumption unit
+* Delete = for [deleting](#delete-a-consumption-unit) the consumption unit
+
+## Create a consumption unit
+
+Catalog Manager or Central Administrator can create consumption unit.
+
+To create a consumption unit:
+
+1. Navigate to *Catalog > Product Foundry* > **Consumption Units**. This open the consumption unit page.
+2. Click **+ Add New Unit** to open the consumption unit creation panel.
+3. Enter the required information:
+   * Display name (mandatory) - Logical name (mandatory), and description (optional)
+4. Click Save
+
+Logical name must start with `x-`, must be unique and cannot be updated later.
+
+## Edit a consumption unit
+
+Catalog Manager or Central Administrator can create consumption unit.
+
+1. Navigate to the *Catalog > Product Foundry* > **Consumption Units**. This open the consumption unit page.
+2. Use the Edit ellipsis menu to open the consumption unit edit panel
+3. Only Display name and description can be edited.
+4. Click Save.
+
+## Delete a consumption unit
+
+Catalog Manager or Central Administrator can create consumption unit.
+
+Delete is only allowed if the consumption unit is not used in any plan quota.
+
+1. Navigate to the *Catalog > Product Foundry* > **Consumption Units**. This open the consumption unit page.
+2. Use the Delete ellipsis menu to open the consumption unit delete confirmation
+3. Confirm your choice by typing Delete.
+
+You can also select multiple consumption units from the list and click the Delete button to delete multiple units at a time.
+
+## Consumption unit multi-language
+
+Catalog Manager or Central Administrator can translate consumption unit.
+
+Consumption units are visible on the Marketplace, it is possible to add their translation so that they can be viewed differently based on the Marketplace language settings.
+
+By default four languages are available : English / French / German / Brazilian Portuguese
+
+You will need 2 things:
+
+* The consumption unit default language
+* The consumption unit translation languages
+
+The language can be accessed using the List view ellipsis menu **Translate**. This will open the *translation details* screen where you can set the Default Language.
+
+Once a default language is selection, you can add the other needed languages by using the translation icon. This will open the translation panel where you can add the translated name and description.

--- a/content/en/docs/manage_product_foundry/manage_product_plans.md
+++ b/content/en/docs/manage_product_foundry/manage_product_plans.md
@@ -16,7 +16,7 @@ Learn how to create and configure the product plan using the Product Foundry Web
 
 **Quotas** - describes the itemized units per resource or group of resources in the product, and how much of those units they are entitled to use over a billing period.
 
-**Units** - defines the billable units. For example: Transactions, Seats, Messages. Used with the quotas to describe the pricing and how many units a consumer is entitled to use.
+**Consumption Units** - defines the billable units. For example: Transactions, Seats, Messages. Used with the quotas to describe the pricing and how many units a consumer is entitled to use.
 
 ## Product plan states
 
@@ -119,12 +119,12 @@ For a Paid plan, each quota can be associated with a cost depending on the quota
 To configure a quota for a **Free plan**, enter the values for the following properties:
 
 * **Quota Name** - a name for the quota.
-* **Quota Type** (only **Standard** is available).
-* **Unit** - the default is **Transactions**. This non-configurable field defines a quota for Transaction units only.
+* **Consumption Unit** - the default is **Transactions**. You can select a different consumption unit if any is available in the system. Refer to [create a consumption unit](/docs/manage_product_foundry/manage_consumption_units#create-a-consumption-unit)
+* **Pricing model** (only **Standard** is available).
 * **Limit** - enter a quantity (for example, 1000, 15) or check Unlimited to not specify any limitation.
 * **Quota Type** - select either **Daily**, **Weekly** or **Monthly**.
 * **Limit Type** (only **Strict** is available) - the gateway enforces a hard stop when the quota limit is exceeded.
-* **Assign Resources** - the list of resources the provider will charge for by a measured unit. Only the resources included in the plan can be selected.
+* **Assign Resources** - the list of resources the provider will charge for by a measured unit. Only the resources included in the plan can be selected. For that click the **+ Add Resources** button to open the resource selector screen.
 
 {{< alert title="Note" color="primary" >}}When Limit Type is set to Strict, make sure the quota is enforced on the underlying gateway.{{< /alert >}}
 {{< alert title="Note" color="primary" >}}When selecting **Unlimited**, Limit, Quota Type and Limit Type are disabled. Be sure the underlying gateway can support the load.{{< /alert >}}
@@ -132,10 +132,12 @@ To configure a quota for a **Free plan**, enter the values for the following pro
 To configure a quota for a **Paid plan**, enter the values for the following properties:
 
 * **Quota Name** - a name for the quota.
-* **Quota Type** - select either **Standard**, **Tiered** or **Pay Per Use**:
+* **Consumption Unit** - the default is **Transactions**. You can select a different consumption unit if any is available in the system. Refer to [create a consumption unit](/docs/manage_product_foundry/manage_consumption_units#create-a-consumption-unit)*
+* **Pricing model** - select either **Standard**, **Tiered - volune**, **Tiered - graduated** or **Pay Per Use**:
     * Standard - has the same information as the free plan (**Unit**, **Limit**, **Quota Type**, **Limit Type**, **Overage** for loose limit type).
     * Tiered - for each tier, enter the **lower limit**, the **upper limit**, the **unit price**, and the **Standard** fees. There is no limit in the tier number. Click **+** to add another tier, or **-** to remove a tier definition. The lower limit of the next tier is automatically computed based on the upper limit of previous tier. The unlimited value is represented with the number 999999999 and automatically added to the last tier **upper limit**.
     * Pay Per Use - select the transaction unit cost.
+* **Assign Resources** - the list of resources the provider will charge for by a measured unit. Only the resources included in the plan can be selected. For that click the **+ Add Resources** button to open the resource selector screen.
 
 {{< alert title="Note" color="primary" >}}
 For Standard Quota Type, the quota period should be equal or less than the plan metering period. If plan metering period is monthly, you cannot define an annual quota period.


### PR DESCRIPTION
Thank you for your contribution to the Amplify-Central repo.

## Describe the changes

Add new page for consumption unit management
Update the quota plan creation description

## Deploy preview link

Unit:
http://pr-557.amplify-central.opendocs-builder.pcloud.axway.int/docs/manage_product_foundry/manage_consumption_units/

Plan Quota:
http://pr-557.amplify-central.opendocs-builder.pcloud.axway.int/docs/manage_product_foundry/manage_product_plans/#configure-a-quota


## Checklist for contributors

Before submitting this PR:

* Verify that all status checks have passed
* For more information on the Markdown linter rules, see [DavidAnson/markdownlint](https://github.com/DavidAnson/markdownlint)
* For first-time contributors, ensure that you have signed the [Axway CLA](https://cla.axway.com/)
