### PR TITLE
Custom credentials handling and agent integration

### DIFF
--- a/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
@@ -173,7 +173,7 @@ APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPE_1=external
 APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPENAME_1=external-crd-name
 ```
 
-For how to handle these custom credentials see [Use Custom Credentials with the Discovery Agent](/docs/connected_agent_common_reference/custom-external-credentials).
+For detailed instructions on (handling/managing) these custom credentials, refer to [Use Custom Credentials with the Discovery Agent](/docs/connected_agent_common_reference/custom-external-credentials).
 
 #### Custom OAuth External policy handling
 

--- a/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
@@ -173,7 +173,7 @@ APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPE_1=external
 APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPENAME_1=external-crd-name
 ```
 
-For detailed instructions on handling these custom credentials, refer to [Use Custom Credentials with the Discovery Agent](/docs/connected_agent_common_reference/custom-external-credentials).
+For detailed instructions on handling these custom credentials, see [Use Custom Credentials with the Discovery Agent](/docs/connect_manage_environ/connected_agent_common_reference/custom-external-credentials).
 
 #### Custom OAuth External policy handling
 

--- a/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
@@ -173,6 +173,8 @@ APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPE_1=external
 APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPENAME_1=external-crd-name
 ```
 
+For how to handle these custom credentials see [Use Custom Credentials with the Discovery Agent](/docs/connected_agent_common_reference/custom-external-credentials).
+
 #### Custom OAuth External policy handling
 
 When a Front End Proxy is secured by an OAuth External policy for an identity provider that does not support OAuth 2.0 Dynamic Client Registration Protocol, the agent will link the API to a Credential Request definition for specifying the identifier of the OAuth client provisioned outside the context of an agent.

--- a/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_api_manager/agent-variables.md
@@ -173,7 +173,7 @@ APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPE_1=external
 APIMANAGER_INVOKEPOLICY_MAPPING_CREDENTIALTYPENAME_1=external-crd-name
 ```
 
-For detailed instructions on (handling/managing) these custom credentials, refer to [Use Custom Credentials with the Discovery Agent](/docs/connected_agent_common_reference/custom-external-credentials).
+For detailed instructions on handling these custom credentials, refer to [Use Custom Credentials with the Discovery Agent](/docs/connected_agent_common_reference/custom-external-credentials).
 
 #### Custom OAuth External policy handling
 

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/custom-external-credentials.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/custom-external-credentials.md
@@ -15,7 +15,7 @@ The Discovery Agent, for certain Gateways, can be configured to allow for handli
 ## Objectives
 
 * Setup your custom credential request definition
-* Set your agent configuration to notify it that the credential request definition is to be handled externally
+* Set your configuration to notify the agent that the credential request definition is to be handled externally
 * Create a Watch Topic or Webhook that an external process may use to subscribe to credential requests
 * Update the requested credential in the proper order to notify the Marketplace consumer
 
@@ -72,11 +72,11 @@ See [Set up integrations through Webhooks](/docs/integrate_with_central/webhooks
 
 ## Updating the Credential resource after provisioning
 
-After the Credential is handled by the custom processing the following updates should be made to the Resource.
+After the Credential is handled by the custom processing, the following updates should be made to the Resource.
 
 ### Encrypting sensitive data within the credential
 
-In order to encrypt any sensitive data, marked *x-axway-encrypted*, in the credential request definition, the custom processing will need public key information. This key can be easily retrieved by retrieving the Managed Application resource that the Credential resource refers to.
+In order to encrypt any sensitive data, marked *x-axway-encrypted*, in the credential request definition, the custom processing will need public key information. This key can be easily obtained by retrieving the Managed Application resource that the Credential resource refers to.
 
 Here is an example of a Managed Application with public key information.
 
@@ -112,7 +112,7 @@ Here is an example of a Managed Application with public key information.
 
 ### Updating the Credential resource
 
-After encrypting any sensitive data the custom handling will make the following updates to the Credential resource.
+After encrypting any sensitive data, the custom handling will make the following updates to the Credential resource.
 
 1. Update the base resource with a new finalizer.
     * A finalizer is a way to tell Marketplace to not immediately remove a resource on delete. In this case the finalizer will allow the custom credential handling to cleanup anything it needs to when the Credential resouce is deleted.
@@ -121,7 +121,7 @@ After encrypting any sensitive data the custom handling will make the following 
 4. Add any data needed for updating or removing the credential in a custom sub-resource
 5. Finally update the status sub-resource marking the credential as Success
 
-Below is an example of the a Credentail resource with the finalizer, encrypted data, custom sub-resource, and updated status added. Simply update the Credential resource like below using the API. This includes a PUT call on the base resource and each of the sub-resource URLs.
+Below is an example of a Credential resource with the finalizer, encrypted data, custom sub-resource, and updated status added. Simply update the Credential resource like below using the API. This includes a PUT call on the base resource and each of the sub-resource URLs.
 
 {{< alert title="Note" color="primary" >}}
 The last API call made must *always* be the status sub-resource

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/custom-external-credentials.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/custom-external-credentials.md
@@ -62,9 +62,9 @@ Handle a credential update event for deletes when...
 * The Credential is marked as `DELETING`
     * Check the `metadata.state` value for `DELETING`
 
-### Integrate using a Watch Topic
+### Integrate using a watch topic
 
-See [Set up integrations through Watch Topics](/docs/integrate_with_central/integrate-with-watchtopics) for a full description of setting up Watch Topics.
+See [Set up integrations through watch topics](/docs/integrate_with_central/integrate-with-watchtopics) for a full description of setting up watch topics.
 
 ### Integrating using a Webhook
 

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/custom-external-credentials.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/custom-external-credentials.md
@@ -8,30 +8,30 @@ The Discovery Agent, for certain Gateways, can be configured to allow for handli
 
 ## Before you start
 
-* [Install and authenticate yourself via the Axway Central CLI](/docs/integrate_with_central/cli_central/cli_install/).
+* [Install and authenticate yourself via the Axway Central CLI](/docs/integrate_with_central/cli_central/cli_install/)
 * Familiarize yourself with [JSON schemas](https://json-schema.org/)
 * Validate that the specific Agent you want to use supports the handling of custom credential types
 
 ## Objectives
 
-* Setup your custom credential request definition
+* Set up your custom credential request definition
 * Set your configuration to notify the agent that the credential request definition is to be handled externally
 * Create a Watch Topic or Webhook that an external process may use to subscribe to credential requests
 * Update the requested credential in the proper order to notify the Marketplace consumer
 
 ## Creating a credential request definition
 
-See [Customize Application Registration, credentials request and subscription screens](/docs/integrate_with_central/customize_ard_crd)
+See [Customize Application Registration, credentials request and subscription screens](/docs/integrate_with_central/customize_ard_crd).
 
 ## Set the agent to ignore the custom credential
 
-Each agent will support setting a custom credential differently, please see the specific agent configuration for how to set this up.
+Each agent will support setting a custom credential differently. See the specific agent configuration for how to set this up.
 
 ## Integrating with Marketplace for handling a custom credential
 
-In both cases, Watch Topic or Webhook, the integration should be setup for create and update events on the Credential resource in your specific Environment.
+In both cases, Watch Topic or Webhook, the integration should be set up for create and update events on the Credential resource in your specific Environment.
 
-Upon receiving an event the process should check a few data points to know that it should handle the event.
+Upon receiving an event, the process checks a few data points to determine whether it should handle the event.
 
 Handle provisioning a new credential when...
 
@@ -68,15 +68,15 @@ See [Set up integrations through Watch Topics](/docs/integrate_with_central/inte
 
 ### Integrating using a Webhook
 
-See [Set up integrations through Webhooks](/docs/integrate_with_central/webhooks) for a full description of setting up Webhooks.
+See [Set up integrations through Webhooks](/docs/integrate_with_central/webhook) for a full description of setting up Webhooks.
 
 ## Updating the Credential resource after provisioning
 
-After the Credential is handled by the custom processing, the following updates should be made to the Resource.
+After the Credential is handled by the custom processing, make the following updates to the Resource.
 
 ### Encrypting sensitive data within the credential
 
-In order to encrypt any sensitive data, marked *x-axway-encrypted*, in the credential request definition, the custom processing will need public key information. This key can be easily obtained by retrieving the Managed Application resource that the Credential resource refers to.
+In order to encrypt any sensitive data, marked *x-axway-encrypted*, in the credential request definition, the custom processing needs public key information. This key can be easily obtained by retrieving the Managed Application resource that the Credential resource refers to.
 
 Here is an example of a Managed Application with public key information.
 
@@ -112,16 +112,16 @@ Here is an example of a Managed Application with public key information.
 
 ### Updating the Credential resource
 
-After encrypting any sensitive data, the custom handling will make the following updates to the Credential resource.
+After encrypting any sensitive data, the custom handling makes the following updates to the Credential resource.
 
 1. Update the base resource with a new finalizer.
-    * A finalizer is a way to tell Marketplace to not immediately remove a resource on delete. In this case the finalizer will allow the custom credential handling to cleanup anything it needs to when the Credential resouce is deleted.
-2. Update the data sub-resource with the provisioned data, inclduing the encrypted and base64 encoded data  
-3. Update the state sub-resource marking the credential as "active"
-4. Add any data needed for updating or removing the credential in a custom sub-resource
-5. Finally update the status sub-resource marking the credential as Success
+    * A finalizer is a way to tell Marketplace to not immediately remove a resource on delete. In this case, the finalizer will allow the custom credential handling to do a cleanup when the Credential resouce is deleted.
+2. Update the data sub-resource with the provisioned data, inclduing the encrypted and base64 encoded data.
+3. Update the state sub-resource marking the credential as "active."
+4. Add any data needed for updating or removing the credential in a custom sub-resource.
+5. Finally, update the status sub-resource marking the credential as "Success."
 
-Below is an example of a Credential resource with the finalizer, encrypted data, custom sub-resource, and updated status added. Simply update the Credential resource like below using the API. This includes a PUT call on the base resource and each of the sub-resource URLs.
+Below is an example of a Credential resource with the finalizer, encrypted data, custom sub-resource, and updated status added. Simply update the Credential resource, as below, using the API. This includes a PUT call on the base resource and each of the sub-resource URLs.
 
 {{< alert title="Note" color="primary" >}}
 The last API call made must *always* be the status sub-resource
@@ -175,4 +175,4 @@ The last API call made must *always* be the status sub-resource
 
 ### Deleting the Credential resource
 
-If the process is handling a delete event the only step that needs to be taken on the resource, after successful handling, is to remove the finalizer that the process added. Doing so will inform Amplify that the Credential resource may be completely removed from the system.
+If the process is handling a delete event, the only step that needs to be taken on the resource, after successful handling, is to remove the finalizer that the process added. Doing so will inform Amplify that the Credential resource may be completely removed from the system.

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/custom-external-credentials.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/custom-external-credentials.md
@@ -29,7 +29,7 @@ Each agent will support setting a custom credential differently, please see the 
 
 ## Integrating with Marketplace for handling a custom credential
 
-In both cases, Watch Topic or Webhook, the integration should be setup for create, update, and delete events on the Credential resource in your specific Environment.
+In both cases, Watch Topic or Webhook, the integration should be setup for create and update events on the Credential resource in your specific Environment.
 
 Upon receiving an event the process should check a few data points to know that it should handle the event.
 
@@ -43,7 +43,7 @@ Handle provisioning a new credential when...
     * Check `status.level` for the status
 * The Credential does not have the finalizer that the process will add
 
-Handle a credential update event when...
+Handle a credential update event for updates when...
 
 * The Credential resource references the custom Credential Request Definition
     * Check `spec.credentialRequestDefinition` for the referenced Credential Request Definition
@@ -54,7 +54,7 @@ Handle a credential update event when...
 * If the `state.name` is `inactive` and the `spec.state.name` is `active` the Credential should be enabled
 * If `state.name` and `spec.state.name` are `active` and `spec.state.rotate` is true then the Credential should be rotated
 
-Handle a credential delete event when...
+Handle a credential update event for deletes when...
 
 * The Credential resource references the custom Credential Request Definition
     * Check `spec.credentialRequestDefinition` for the referenced Credential Request Definition

--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/custom-external-credentials.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/custom-external-credentials.md
@@ -1,0 +1,143 @@
+---
+title: Use Custom Credentials with the Discovery Agent
+linkTitle: Use Custom Credentials with the Discovery Agent
+draft: false
+weight: 10
+---
+The Discovery Agent, for certain Gateways, can be configured to allow for handling a specified credential request type outside of the normal agent processing. This can be useful for cases where custom attributes or special processing is required that the agent does not know about.
+
+## Before you start
+
+* [Install and authenticate yourself via the Axway Central CLI](/docs/integrate_with_central/cli_central/cli_install/).
+* Familiarize yourself with [JSON schemas](https://json-schema.org/)
+* Validate that the specific Agent you want to use supports the handling of custom credential types
+
+## Objectives
+
+* Setup your custom credential request definition
+* Set your agent configuration to notify it that the credential request definition is to be handled externally
+* Create a Watch Topic or Webhook that an external process may use to subscribe to credential requests
+* Update the requested credential in the proper order to notify the Marketplace consumer
+
+## Creating a credential request definition
+
+See [Customize Application Registration, credentials request and subscription screens](/docs/integrate_with_central/customize_ard_crd)
+
+## Set the agent to ignore the custom credential
+
+Each agent will support setting a custom credential differently, please see the specific agent configuration for how to set this up.
+
+## Integrating with Marketplace for handling a custom credential
+
+In both cases, Watch Topic or Webhook, the integration should be setup for create, update, and delete events on the Credential resource in your specific Environment.
+
+### Integrate using a Watch Topic
+
+See [Set up integrations through Watch Topics](/docs/integrate_with_central/integrate-with-watchtopics) for a full description of setting up Watch Topics.
+
+### Integrating using a Webhook
+
+See [Set up integrations through Webhooks](/docs/integrate_with_central/webhooks) for a full description of setting up Webhooks.
+
+## Updating the Credential resource after provisioning
+
+After the Credential is handled by the custom processing the following updates should be made to the Resource.
+
+### Encrypting sensitive data within the credential
+
+In order to encrypt any sensitive data, marked *x-axway-encrypted*, in the credential request definition, the custom processing will need public key information. This key can be easily retrieved by retrieving the Managed Application resource that the Credential resource refers to.
+
+Here is an example of a Managed Application with public key information.
+
+```json
+{
+    "group": "management",
+    "apiVersion": "v1alpha1",
+    "kind": "ManagedApplication",
+    "name": "my-app",
+    "title": "My Application",
+    "metadata": {
+        "scope": {
+            "kind": "Environment",
+            "name": "my-env",
+        }
+    },
+    "attributes": {},
+    "finalizers": [
+        {
+            "name": "agent.managedapplication.provisioned"
+        }
+    ],
+    "tags": [],
+    "spec": {
+        "security": {
+            "encryptionKey": "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAzjKAKBf6LHiGit25qttm\n0Me8K2AMf7gVsVR4G+2Ir+cZwRg3PN7mLn2R5OEtCLxN/v5GcECojkN2L+4OrsKA\nH+ZnT86NgmN00Kvj6D0S4rXuzY6AmbpWqA2ynJX1XTe0Ao4mREjbk23GlpqCumcI\nbuxRxk5HesDL3PiXhftF1adZva1HBZQHLE0TWdoitWmVr9Go6ZCdzk1luASdyBxD\nodOu+63wI1a3y9yqtsceEAG/Yn4uDckYo2jQDtev8db85b4sUNENQFsWOZj+iUwH\nR1sFUEFA58VGSn9vcZ8Wz+Rn1EyH333SemBC1vlWzt05cQ+F/GfE86IlnNmOswjn\nF7qzcOO50wnUm6WhGwuQKfTgrhfsBFH2GaHrWsRytscGTaPUezklYCMp1NXY6kG5\nAKHoXhW1gyPYUY5YxF57/kglDJ5Q1kt52QXTBpqVcYWEbUha1+pU9g2MY6KEBRKC\ny64i5+EsZ6SQIlZN+hIhOI+NY2LWtWew8ViCErWCiGmNATnTDYExyXa+eL/pokIH\n7cmQP20dOIyJq6AL6e/SLrSFyYMIZEVXpsTS9ZIJTm1ebmFz16k4NFCcZLv1gVha\nFzTMKrLDccvcUv4M/S+GCdopnSc9wdEvk9WZ2G2uH8MvNyphe7NSpVo8xv2Th4jg\nZAQx+dcis026rM0fDGj78w0CAwEAAQ==\n-----END PUBLIC KEY-----",
+            "encryptionHash": "SHA256",
+            "encryptionAlgorithm": "RSA-OAEP"
+        }
+    }
+}
+```
+
+### Updating the Credential resource
+
+After encrypting any sensitive data the custom handling will make the following updates to the Credential resource.
+
+1. Update the base resource with a new finalizer.
+    * A finalizer is a way to tell Marketplace to not immediately remove a resource on delete. In this case the finalizer will allow the custom credential handling to cleanup anything it needs to when the Credential resouce is deleted.
+2. Update the data sub-resource with the provisioned data, inclduing the encrypted and base64 encoded data  
+3. Update the state sub-resource marking the credential as "active"
+4. Add any data needed for updating or removing the credential in a custom sub-resource
+5. Finally update the status sub-resource marking the credential as Success
+
+Below is an example of the a Credentail resource with the finalizer, encrypted data, custom sub-resource, and updated status added. Simply update the Credential resource like below using the API. This includes a PUT call on the base resource and each of the sub-resource URLs.
+
+{{< alert title="Note" color="primary" >}}
+The last API call made must *always* be the status sub-resource
+{{< /alert >}}
+
+```json
+{
+    "group": "management",
+    "apiVersion": "v1alpha1",
+    "kind": "Credential",
+    "name": "consumer-cred",
+    "title": "Consumer Credential",
+    "metadata": {
+        "scope": {
+            "kind": "Environment",
+            "name": "my-env"
+        }
+    },
+    "attributes": {},
+    "finalizers": [
+        {
+            "name": "custom.credential.provisioned"
+        }
+    ],
+    "tags": [],
+    "spec": {
+        "data": {
+            "requested-data": "provided-value"
+        },
+        "state": {
+            "name": "active"
+        },
+        "managedApplication": "my-app",
+        "credentialRequestDefinition": "my-custom-credential"
+    },
+     "data": {
+        "encyrpted-data": "K3vFk1A/LYBjAXePdkneuQ+dR+6RwrvWYZsPDokyfV/JIt9uI1/iwxlv6u0Bu+Nep7+EVKEMZhYbhV+PMBGn80tAZsypOg2HDVRw1HdnibRLic7fRvwwCS4uu3Yssu4PKJYiWxpJYY16cC84XtDlsmnnM+E+82GSn2nAU0NCjv77v+JrenD3xxVJVT+Q9wOkq3sdaUr3W38lLUWJNxGbaWFhWlvecWZ5wnjhwIFhM6wuSMVFJep9N4j4WOhosFCSvIyUbwvHjW07qq3NeTEnMJqrqBYo82RvcYf+/+A/BT/mZPtEpt7RsTnTbGljVdS6a+GYGAlQ8alpT82Mdgu0i8vvTI+BFAF/t5oS0iFAUuDEuakfnDrOvAAzLFZmE/51G/mWZsFFzSqsHsze/OUS1PUnnSUxbI/XmBSZ4iqHEQs0O5q9riE+Hm8PI/soTTrY8ZCAH+FXpJd1go5Mi70="
+    },
+    "state": {
+        "name": "active"
+    },
+    "x-custom-credential": {
+        "my-data-1": "9e1ade34-ec3d-446f-8387-4cda0ed368f4",
+        "my-data-2": "17626962051421552363"
+    },
+    "status": {
+        "level": "Success"
+    }
+}
+```

--- a/content/en/docs/integrate_with_central/integrate-with-watchtopics.md
+++ b/content/en/docs/integrate_with_central/integrate-with-watchtopics.md
@@ -1,6 +1,6 @@
 ---
-title: Set up integrations through Watch Topics
-linkTitle: Set up integrations through Watch Topics
+title: Set up integrations through watch topics
+linkTitle: Set up integrations through watch topics
 weight: 100
 hide_readingtime: true
 ---
@@ -19,13 +19,13 @@ Common scenarios to integrate through watch topics are the following items:
 
 Learn how to create and configure watch topics in Amplify, as well as the event structure that corresponds to a set of actions.
 
-## Watch Topic
+## Watch topic
 
 A watch topic is an API resource that is defined in such a way that a single topic may be used to keep track of changes on other specific API Server resources. For example, when a new Credential is created in a given environment any watch topics that are set to track those credential resources will have a new event to handle.
 
 ### Create a watch topic
 
-Create a watchtopic using API:
+Create a watch topic using API:
 
 ```bash
 curl --location 'https://apicentral.axway.com/apis/management/v1alpha1/watchtopics' \
@@ -56,7 +56,7 @@ curl --location 'https://apicentral.axway.com/apis/management/v1alpha1/watchtopi
 }'
 ```
 
-Or create a watchtopic using the Axway CLI: Add the following in a file and apply the file `axway central apply -f {filename.yaml}`
+Or create a watch topic using the Axway CLI. Add the following in a file and apply the file `axway central apply -f {filename.yaml}`:
 
 ```yaml
 group: management
@@ -80,17 +80,17 @@ spec:
   description: "Watch Topic for handling custom credentials."
 ```
 
-### Read events form a watch topic
+### Read events from a watch topic
 
-Events in the WatchTopic are sequential and will be available for seven days.
+Events in the watch topic are sequential and will be available for seven days.
 
-To request for all events in the watch topic query the API as below. It will return all events from oldest to newest.
+To request all events in the watch topic, query the API as shown below. It will return all events from oldest to newest.
 
 ```bash
 curl --location 'https://apicentral.axway.com/events/management/v1alpha1/watchtopics/custom-credentials-in-my-env?sort=sequenceID
 ```
 
-After handling the events, follow up calls to the API should include a query using the sequenceID parameter as well as sequenceID for the last handled event `query=sequenceID>[id]`. Including the parameter argument will give only events that have been created after that sequenceID.
+After handling the events, follow up calls to the API should include a query using the sequenceID parameter, as well as sequenceID for the last handled event `query=sequenceID>[id]`. Including the parameter argument will give only events that have been created after that sequenceID.
 
 ```bash
 curl --location 'https://apicentral.axway.com/events/management/v1alpha1/watchtopics/custom-credentials-in-my-env?sort=sequenceID
@@ -203,12 +203,12 @@ Each of the above calls will return an array of events that have occurred for a 
 
 In addition to receiving events by querying the above API at a specific duration, it is also possible to create a gRPC service that connects to Amplify directly.
 
-The Agent SDK can be referenced on how to build a watch client using Go, see the steps below for implementing.
+The Agent SDK can be referenced on how to build a watch client using Go. To implement:
 
-1. Building a specific client based on our [Agent SDK](https://github.com/Axway/agent-sdk) to listen to the WatchTopic. See the [Sample of gRPC client source code](https://github.com/Axway/agent-sdk/tree/main/samples/watchclient).
-2. Compile this source code with go compiler to get the executable: `go make`
-3. An Amplify Service Account with Central Admin rights is needed to run the client. The service account key pair should be in the same directory with the gRPC client.
-4. Start the gRPC client
+1. Building a specific client based on our [Agent SDK](https://github.com/Axway/agent-sdk) to listen to the watch topic. See the [Sample of gRPC client source code](https://github.com/Axway/agent-sdk/tree/main/samples/watchclient).
+2. Compile this source code with go compiler to get the executable: `go make`.
+3. An Amplify Service Account with Central Admin rights is needed to run the client. The service account key pair must be in the same directory with the gRPC client.
+4. Start the gRPC client:
 
     ```cmd
     ./watchclient --auth.client_id=<sa_client_id> --tenant_id=<organization_id> --host=apicentral.axway.com --port=443 --topic_self_link=/management/v1alpha1/watchtopics/track-subscriptions-invoices --log_level=debug --auth.url="
@@ -217,4 +217,4 @@ The Agent SDK can be referenced on how to build a watch client using Go, see the
 
 Using the above queries, the gRPC client can process all events, and manage some failover, by keeping track of the event sequence numbers. For instance, you can save locally the latest processed sequence and, on client restart, process the event that may have been missed while the client was down.
 
-Go is not required as the [Agent SDK](https://github.com/Axway/agent-sdk) does provide the [protobuf definition](https://github.com/Axway/agent-sdk/blob/main/proto/watch.proto). Use this definition and implement a watch client in any language that [Protocol Buffers](https://protobuf.dev/) supports.
+Go is not required, as the [Agent SDK](https://github.com/Axway/agent-sdk) does provide the [protobuf definition](https://github.com/Axway/agent-sdk/blob/main/proto/watch.proto). Use this definition and implement a watch client in any language that [Protocol Buffers](https://protobuf.dev/) supports.

--- a/content/en/docs/integrate_with_central/integrate-with-watchtopics.md
+++ b/content/en/docs/integrate_with_central/integrate-with-watchtopics.md
@@ -42,7 +42,6 @@ curl --location 'https://apicentral.axway.com/apis/management/v1alpha1/watchtopi
                 "name": "*",
                 "type": [
                     "created",
-                    "deleted",
                     "updated"
                 ],
                 "scope": {
@@ -73,7 +72,6 @@ spec:
       name: '*'
       type:
         - created
-        - deleted
         - updated
       group: management
       scope:

--- a/content/en/docs/integrate_with_central/integrate-with-watchtopics.md
+++ b/content/en/docs/integrate_with_central/integrate-with-watchtopics.md
@@ -21,7 +21,7 @@ Learn how to create and configure watch topics in Amplify, as well as the event 
 
 ## Watch Topic
 
-A watch topic is an API resource that is defined in such a way that a single topic may be used to keep track of changes on other specific API Server resources. For example when a new Credential is created in a given environment any watch topics that are set to track those credential resources will have a new event to handle.
+A watch topic is an API resource that is defined in such a way that a single topic may be used to keep track of changes on other specific API Server resources. For example, when a new Credential is created in a given environment any watch topics that are set to track those credential resources will have a new event to handle.
 
 ### Create a watch topic
 
@@ -84,7 +84,7 @@ spec:
 
 ### Read events form a watch topic
 
-Events in the WatchTopic are sequential and will available for seven days.
+Events in the WatchTopic are sequential and will be available for seven days.
 
 To request for all events in the watch topic query the API as below. It will return all events from oldest to newest.
 
@@ -92,13 +92,13 @@ To request for all events in the watch topic query the API as below. It will ret
 curl --location 'https://apicentral.axway.com/events/management/v1alpha1/watchtopics/custom-credentials-in-my-env?sort=sequenceID
 ```
 
-After handling the events follow up calls to the API should include a query using the sequenceID parameter as well as sequenceID for the last handled event `query=sequenceID>[id]`. Including the parameter argument will give only events that have been created after that sequenceID.
+After handling the events, follow up calls to the API should include a query using the sequenceID parameter as well as sequenceID for the last handled event `query=sequenceID>[id]`. Including the parameter argument will give only events that have been created after that sequenceID.
 
 ```bash
 curl --location 'https://apicentral.axway.com/events/management/v1alpha1/watchtopics/custom-credentials-in-my-env?sort=sequenceID
 ```
 
-Each of the above calls well return an array of events that have occurred for a given watch topic.
+Each of the above calls will return an array of events that have occurred for a given watch topic.
 
 ```json
 [

--- a/content/en/docs/integrate_with_central/integrate-with-watchtopics.md
+++ b/content/en/docs/integrate_with_central/integrate-with-watchtopics.md
@@ -4,7 +4,7 @@ linkTitle: Set up integrations through Watch Topics
 weight: 100
 hide_readingtime: true
 ---
-Amplify enables the user to augment the default functionality through the integration of third-party systems and functionality. One of the ways this can be accomplished is with inbuilt events in combination with watch topics.
+Amplify enables the user to augment the default functionality through the integration of third-party systems. One of the ways this can be accomplished is with inbuilt events in combination with watch topics.
 
 Common scenarios to integrate through watch topics are the following items:
 
@@ -27,7 +27,7 @@ A watch topic is an API resource that is defined in such a way that a single top
 
 Create a watchtopic using API:
 
-```json
+```bash
 curl --location 'https://apicentral.axway.com/apis/management/v1alpha1/watchtopics' \
 --data '{
     "group": "management",

--- a/content/en/docs/integrate_with_central/integrate-with-watchtopics.md
+++ b/content/en/docs/integrate_with_central/integrate-with-watchtopics.md
@@ -198,3 +198,23 @@ Each of the above calls will return an array of events that have occurred for a 
     }
 ]
 ```
+
+### Integrating with gRPC
+
+In addition to receiving events by querying the above API at a specific duration, it is also possible to create a gRPC service that connects to Amplify directly.
+
+The Agent SDK can be referenced on how to build a watch client using Go, see the steps below for implementing.
+
+1. Building a specific client based on our [Agent SDK](https://github.com/Axway/agent-sdk) to listen to the WatchTopic. See the [Sample of gRPC client source code](https://github.com/Axway/agent-sdk/tree/main/samples/watchclient).
+2. Compile this source code with go compiler to get the executable: `go make`
+3. An Amplify Service Account with Central Admin rights is needed to run the client. The service account key pair should be in the same directory with the gRPC client.
+4. Start the gRPC client
+
+    ```cmd
+    ./watchclient --auth.client_id=<sa_client_id> --tenant_id=<organization_id> --host=apicentral.axway.com --port=443 --topic_self_link=/management/v1alpha1/watchtopics/track-subscriptions-invoices --log_level=debug --auth.url="
+    https://login.axway.com/auth"
+    ```
+
+Using the above queries, the gRPC client can process all events, and manage some failover, by keeping track of the event sequence numbers. For instance, you can save locally the latest processed sequence and, on client restart, process the event that may have been missed while the client was down.
+
+Go is not required as the [Agent SDK](https://github.com/Axway/agent-sdk) does provide the [protobuf definition](https://github.com/Axway/agent-sdk/blob/main/proto/watch.proto). Use this definition and implement a watch client in any language that [Protocol Buffers](https://protobuf.dev/) supports.

--- a/content/en/docs/integrate_with_central/integrate-with-watchtopics.md
+++ b/content/en/docs/integrate_with_central/integrate-with-watchtopics.md
@@ -1,0 +1,202 @@
+---
+title: Set up integrations through Watch Topics
+linkTitle: Set up integrations through Watch Topics
+weight: 100
+hide_readingtime: true
+---
+Amplify enables the user to augment the default functionality through the integration of third-party systems and functionality. One of the ways this can be accomplished is with inbuilt events in combination with watch topics.
+
+Common scenarios to integrate through watch topics are the following items:
+
+* Manage custom credential handling
+* Manage subscription invoices for custom billing
+
+## Before you start
+
+* You understand the concepts involved in the [API Server](/docs/integrate_with_central/api_server/).
+
+## Objectives
+
+Learn how to create and configure watch topics in Amplify, as well as the event structure that corresponds to a set of actions.
+
+## Watch Topic
+
+A watch topic is an API resource that is defined in such a way that a single topic may be used to keep track of changes on other specific API Server resources. For example when a new Credential is created in a given environment any watch topics that are set to track those credential resources will have a new event to handle.
+
+### Create a watch topic
+
+Create a watchtopic using API:
+
+```json
+curl --location 'https://apicentral.axway.com/apis/management/v1alpha1/watchtopics' \
+--data '{
+    "group": "management",
+    "apiVersion": "v1alpha1",
+    "kind": "WatchTopic",
+    "name": "custom-credentials-in-my-env",
+    "title": "Custom Credential in My Environment",
+    "spec": {
+        "filters": [
+            {
+                "kind": "Credential",
+                "name": "*",
+                "type": [
+                    "created",
+                    "deleted",
+                    "updated"
+                ],
+                "scope": {
+                    "kind": "Environment",
+                    "name": "my-env"
+                },
+                "group": "management"
+            }
+        ],
+        "description": "Watch Topic for handling custom credentials."
+    }
+}'
+```
+
+Or create a watchtopic using the Axway CLI: Add the following in a file and apply the file `axway central apply -f {filename.yaml}`
+
+```yaml
+group: management
+apiVersion: v1alpha1
+kind: WatchTopic
+name: custom-credentials-in-my-env
+title: Custom Credential in My Environment
+attributes: {}
+tags: []
+spec:
+  filters:
+    - kind: Credential
+      name: '*'
+      type:
+        - created
+        - deleted
+        - updated
+      group: management
+      scope:
+        kind: Environment
+        name: 'my-env'
+  description: "Watch Topic for handling custom credentials."
+```
+
+### Read events form a watch topic
+
+Events in the WatchTopic are sequential and will available for seven days.
+
+To request for all events in the watch topic query the API as below. It will return all events from oldest to newest.
+
+```bash
+curl --location 'https://apicentral.axway.com/events/management/v1alpha1/watchtopics/custom-credentials-in-my-env?sort=sequenceID
+```
+
+After handling the events follow up calls to the API should include a query using the sequenceID parameter as well as sequenceID for the last handled event `query=sequenceID>[id]`. Including the parameter argument will give only events that have been created after that sequenceID.
+
+```bash
+curl --location 'https://apicentral.axway.com/events/management/v1alpha1/watchtopics/custom-credentials-in-my-env?sort=sequenceID
+```
+
+Each of the above calls well return an array of events that have occurred for a given watch topic.
+
+```json
+[
+    {
+        "id": "acb8e658-5871-473b-9177-99c16c0bc25f",
+        "time": "2024-10-28 15:43:02.689148",
+        "version": "v1",
+        "product": "AmplifyCentral",
+        "correlationId": "18d2ef01-c04a-40a3-b959-d9f37ca733f3",
+        "organization": {
+            "id": "org-id"
+        },
+        "type": "ResourceCreated",
+        "payload": {
+            "group": "management",
+            "kind": "Credential",
+            "name": "my-new-credential",
+            "finalizers": null,
+            "attributes": {},
+            "tags": [],
+            "metadata": {
+                "id": "8ac98c5a92d38a930192d3cb81720189",
+                "selfLink": "/management/v1alpha1/environments/my-env/credential/my-new-credential",
+                "references": [
+                    {
+                        "id": "8ac98c5a92d38a930192d3cb6fb00174",
+                        "group": "management",
+                        "kind": "ManagedApplication",
+                        "name": "my-app",
+                        "title": null,
+                        "scopeName": null,
+                        "scopeKind": null,
+                        "selfLink": "/management/v1alpha1/environments/my-env/managedapplications/my-app",
+                        "type": "HARD"
+                    }
+                ],
+                "scope": {
+                    "id": "8ac9887192467328019249e58c01014f",
+                    "kind": "Environment",
+                    "name": "my-env",
+                    "selfLink": "/management/v1alpha1/environments/my-envedge"
+                }
+            }
+        },
+        "metadata": {
+            "watchTopicSelfLink": "/management/v1alpha1/watchtopics/custom-credentials-in-my-env",
+            "watchTopicID": "8ac9858191a360160191a3a32365001d",
+            "sequenceID": 284734,
+            "subresource": null
+        }
+    },
+    {
+        "id": "3c8e4073-aa47-4694-b74f-783ff35e9966",
+        "time": "2024-10-28 15:43:02.707423",
+        "version": "v1",
+        "product": "AmplifyCentral",
+        "correlationId": "18d2ef01-c04a-40a3-b959-d9f37ca711f3",
+        "organization": {
+            "id": "org-id"
+        },
+        "type": "ResourceUpdated",
+        "payload": {
+            "group": "management",
+            "kind": "Credential",
+            "name": "my-new-credential",
+            "finalizers": null,
+            "attributes": {},
+            "tags": [],
+            "metadata": {
+                "id": "8ac98c5a92d38a930192d3cb81720189",
+                "selfLink": "/management/v1alpha1/environments/my-env/credential/my-new-credential",
+                "references": [
+                    {
+                        "id": "8ac98c5a92d38a930192d3cb6fb00174",
+                        "group": "management",
+                        "kind": "ManagedApplication",
+                        "name": "my-app",
+                        "title": null,
+                        "scopeName": null,
+                        "scopeKind": null,
+                        "selfLink": "/management/v1alpha1/environments/my-env/managedapplications/my-app",
+                        "type": "HARD"
+                    }
+                ],
+                "scope": {
+                    "id": "8ac9887192467328019249e58c01014f",
+                    "kind": "Environment",
+                    "name": "my-env",
+                    "selfLink": "/management/v1alpha1/environments/my-envedge"
+                }
+            }
+        },
+        "metadata": {
+            "watchTopicSelfLink": "/management/v1alpha1/watchtopics/custom-credentials-in-my-env",
+            "watchTopicID": "8ac9858191a360160191a3a32365001d",
+            "sequenceID": 284747,
+            "subresource": null
+        }
+    }
+]
+```


### PR DESCRIPTION
## Describe the changes

Add documentation on using watch topics and custom credentail handling within an agent context 

## Deploy preview link

- [Invoke policy mapping link to new doc](http://pr-558.amplify-central.opendocs-builder.pcloud.axway.int/docs/connect_manage_environ/connect_api_manager/agent-variables/#invoke-policy-mapping-to-externally-managed-credential-request-definition-example)
- [Custom credentials](http://pr-558.amplify-central.opendocs-builder.pcloud.axway.int/docs/connect_manage_environ/connected_agent_common_reference/custom-external-credentials/)
- [Watch Topic integration](http://pr-558.amplify-central.opendocs-builder.pcloud.axway.int/docs/integrate_with_central/integrate-with-watchtopics/)
