### PR TITLE
APIGOV-30479 - update apigee docs with new role apigee.organizations.get to allow data residency

### DIFF
--- a/content/en/docs/connect_manage_environ/connect_apigee_x/_index.md
+++ b/content/en/docs/connect_manage_environ/connect_apigee_x/_index.md
@@ -120,6 +120,7 @@ apigee.environments.getStats
 apigee.proxyrevisions.get
 apigee.resourcefiles.get
 apigee.resourcefiles.list
+apigee.organizations.get
 ```
 
 ### GCP service account

--- a/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
@@ -22,17 +22,14 @@ All common agent variables can be found [here](/docs/connect_manage_environ/conn
 
 ### Common variables to both agents
 
-| Variable name             | Description                                                                                             |
-|---------------------------|---------------------------------------------------------------------------------------------------------|
-| APIGEE_AUTHFILEPATH       | The path where you put the GCP authentication file in docker container (**Ground agent only**)          |
-| APIGEE_CONTROLPLANEREGION | The physical location, specified during provisioning, where Apigee control plane data will be stored    |
-| APIGEE_PROJECTID          | The Project ID for your GCP project                                                                     |
-| APIGEE_DEVELOPEREMAIL     | The Apigee developer email                                                                              |
-| APIGEE_MODE               | Apigee agent running mode (*proxy* or *product*; default: *proxy*)                                      |
-| APIGEE_ENVIRONMENT        | The environment from which metrics are gathered                                                         |
-| APIGEE_CLIENTTIMEOUT      | Maximum amount of time to wait for a reply from the Apigee client (default: 1m)                         |
-
-If the agent requires data residency, you can configure variable `APIGEE_CONTROLPLANEREGION`, which will get prepended to the service endpoint: `CONTROL_PLANE_LOCATION-apigee.googleapis.com`. More information regarding data residency can be found [here](https://cloud.google.com/apigee/docs/api-platform/get-started/drz-concepts#data-residency-service-endpoint) and [here](https://cloud.google.com/apigee/docs/locations#available-apigee-api-control-plane-hosting-jurisdictions).
+| Variable name         | Description                                                                                    |
+|-----------------------|------------------------------------------------------------------------------------------------|
+| APIGEE_AUTHFILEPATH   | The path where you put the GCP authentication file in docker container (**Ground agent only**) |
+| APIGEE_PROJECTID      | The Project ID for your GCP project                                                            |
+| APIGEE_DEVELOPEREMAIL | The Apigee developer email                                                                     |
+| APIGEE_MODE           | Apigee agent running mode (*proxy* or *product*; default: *proxy*)                             |
+| APIGEE_ENVIRONMENT    | The environment from which metrics are gathered                                                |
+| APIGEE_CLIENTTIMEOUT  | Maximum amount of time to wait for a reply from the Apigee client (default: 1m)                |
 
 ### Specific variables for Traceability Agent
 

--- a/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
@@ -27,7 +27,6 @@ All common agent variables can be found [here](/docs/connect_manage_environ/conn
 | APIGEE_AUTHFILEPATH   | The path where you put the GCP authentication file in docker container (**Ground agent only**) |
 | APIGEE_PROJECTID      | The Project ID for your GCP project                                                            |
 | APIGEE_DEVELOPEREMAIL | The Apigee developer email                                                                     |
-| APIGEE_MODE           | Apigee agent running mode (*proxy* or *product*; default: *proxy*)                             |
 | APIGEE_ENVIRONMENT    | The environment from which metrics are gathered                                                |
 | APIGEE_CLIENTTIMEOUT  | Maximum amount of time to wait for a reply from the Apigee client (default: 1m)                |
 

--- a/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
@@ -22,18 +22,21 @@ All common agent variables can be found [here](/docs/connect_manage_environ/conn
 
 ### Common variables to both agents
 
-| Variable name           | Description                                                                                    |
-|-------------------------|------------------------------------------------------------------------------------------------|
-| APIGEE_AUTHFILEPATH     | The path where you put the GCP authentication file in docker container (**Ground agent only**) |
-| APIGEE_PROJECTID        | the Project ID for your GCP project                                                            |
-| APIGEE_DEVELOPEREMAIL   | The Apigee developer email                                                                     |
-| APIGEE_MODE             | Apigee agent running mode (*proxy* or *product*; default: *proxy*)                             |
-| APIGEE_ENVIRONMENT      | The environment from which metrics are gathered                                                |
-| APIGEE_CLIENTTIMEOUT    | Maximum amount of time to wait for a reply from the Apigee client (default: 1m)                |
+| Variable name          | Description                                                                                               |
+|------------------------|-----------------------------------------------------------------------------------------------------------|
+| APIGEE_AUTHFILEPATH    | The path where you put the GCP authentication file in docker container (**Ground agent only**)            |
+| APIGEE_SERVICEENDPOINT | The service endpoint URL where the API Services reside. Default value is `https://apigee.googleapis.com/` |
+| APIGEE_PROJECTID       | The Project ID for your GCP project                                                                       |
+| APIGEE_DEVELOPEREMAIL  | The Apigee developer email                                                                                |
+| APIGEE_MODE            | Apigee agent running mode (*proxy* or *product*; default: *proxy*)                                        |
+| APIGEE_ENVIRONMENT     | The environment from which metrics are gathered                                                           |
+| APIGEE_CLIENTTIMEOUT   | Maximum amount of time to wait for a reply from the Apigee client (default: 1m)                           |
+
+If the agent requires data residency, you can prepend the control plan region to the service endpoint: `CONTROL_PLANE_LOCATION-apigee.googleapis.com`. More information regarding data residency can be found [here](https://cloud.google.com/apigee/docs/api-platform/get-started/drz-concepts#data-residency-service-endpoint).
 
 ### Specific variables for Traceability Agent
 
-| Variable name                        | Description                                                                            |
-|--------------------------------------|----------------------------------------------------------------------------------------|
-| APIGEE_METRICSFILTER_FILTEREDAPIS    | The names of the APIs for which the metrics will be processed                          |
-| APIGEE_METRICSFILTER_FILTERMETRICS   | The flag upon which is decided if the API metrics are filtered or not (default: false) |
+| Variable name                      | Description                                                                            |
+|------------------------------------|----------------------------------------------------------------------------------------|
+| APIGEE_METRICSFILTER_FILTEREDAPIS  | The names of the APIs for which the metrics will be processed                          |
+| APIGEE_METRICSFILTER_FILTERMETRICS | The flag upon which is decided if the API metrics are filtered or not (default: false) |

--- a/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
@@ -25,14 +25,14 @@ All common agent variables can be found [here](/docs/connect_manage_environ/conn
 | Variable name             | Description                                                                                             |
 |---------------------------|---------------------------------------------------------------------------------------------------------|
 | APIGEE_AUTHFILEPATH       | The path where you put the GCP authentication file in docker container (**Ground agent only**)          |
-| APIGEE_CONTROLPLANEREGION | The physical location, specified during provisioning, at which Apigee control plane data will be stored |
+| APIGEE_CONTROLPLANEREGION | The physical location, specified during provisioning, where Apigee control plane data will be stored    |
 | APIGEE_PROJECTID          | The Project ID for your GCP project                                                                     |
 | APIGEE_DEVELOPEREMAIL     | The Apigee developer email                                                                              |
 | APIGEE_MODE               | Apigee agent running mode (*proxy* or *product*; default: *proxy*)                                      |
 | APIGEE_ENVIRONMENT        | The environment from which metrics are gathered                                                         |
 | APIGEE_CLIENTTIMEOUT      | Maximum amount of time to wait for a reply from the Apigee client (default: 1m)                         |
 
-If the agent requires data residency, you can configure variable `APIGEE_CONTROLPLANEREGION`, which will get prepended to the service endpoint: `CONTROL_PLANE_LOCATION-apigee.googleapis.com`. More information regarding data residency can be found [here](https://cloud.google.com/apigee/docs/api-platform/get-started/drz-concepts#data-residency-service-endpoint) and[here](https://cloud.google.com/apigee/docs/locations#available-apigee-api-control-plane-hosting-jurisdictions).
+If the agent requires data residency, you can configure variable `APIGEE_CONTROLPLANEREGION`, which will get prepended to the service endpoint: `CONTROL_PLANE_LOCATION-apigee.googleapis.com`. More information regarding data residency can be found [here](https://cloud.google.com/apigee/docs/api-platform/get-started/drz-concepts#data-residency-service-endpoint) and [here](https://cloud.google.com/apigee/docs/locations#available-apigee-api-control-plane-hosting-jurisdictions).
 
 ### Specific variables for Traceability Agent
 

--- a/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
@@ -25,14 +25,14 @@ All common agent variables can be found [here](/docs/connect_manage_environ/conn
 | Variable name          | Description                                                                                               |
 |------------------------|-----------------------------------------------------------------------------------------------------------|
 | APIGEE_AUTHFILEPATH    | The path where you put the GCP authentication file in docker container (**Ground agent only**)            |
-| APIGEE_SERVICEENDPOINT | The service endpoint URL where the API Services reside. Default value is `https://apigee.googleapis.com/` |
+| APIGEE_SERVICEENDPOINT | The service endpoint URL where the API services reside. Default value is `https://apigee.googleapis.com/` |
 | APIGEE_PROJECTID       | The Project ID for your GCP project                                                                       |
 | APIGEE_DEVELOPEREMAIL  | The Apigee developer email                                                                                |
 | APIGEE_MODE            | Apigee agent running mode (*proxy* or *product*; default: *proxy*)                                        |
 | APIGEE_ENVIRONMENT     | The environment from which metrics are gathered                                                           |
 | APIGEE_CLIENTTIMEOUT   | Maximum amount of time to wait for a reply from the Apigee client (default: 1m)                           |
 
-If the agent requires data residency, you can prepend the control plan region to the service endpoint: `CONTROL_PLANE_LOCATION-apigee.googleapis.com`. More information regarding data residency can be found [here](https://cloud.google.com/apigee/docs/api-platform/get-started/drz-concepts#data-residency-service-endpoint).
+If the agent requires data residency, you can prepend the control plane region to the service endpoint: `CONTROL_PLANE_LOCATION-apigee.googleapis.com`. More information regarding data residency can be found [here](https://cloud.google.com/apigee/docs/api-platform/get-started/drz-concepts#data-residency-service-endpoint).
 
 ### Specific variables for Traceability Agent
 

--- a/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
@@ -22,17 +22,17 @@ All common agent variables can be found [here](/docs/connect_manage_environ/conn
 
 ### Common variables to both agents
 
-| Variable name                  | Description                                                                                               |
-|--------------------------------|-----------------------------------------------------------------------------------------------------------|
-| APIGEE_AUTHFILEPATH            | The path where you put the GCP authentication file in docker container (**Ground agent only**)            |
-| APIGEE_SERVICEENDPOINTLOCATION | The service endpoint URL where the API services reside. Default value is `https://apigee.googleapis.com/` |
-| APIGEE_PROJECTID               | The Project ID for your GCP project                                                                       |
-| APIGEE_DEVELOPEREMAIL          | The Apigee developer email                                                                                |
-| APIGEE_MODE                    | Apigee agent running mode (*proxy* or *product*; default: *proxy*)                                        |
-| APIGEE_ENVIRONMENT             | The environment from which metrics are gathered                                                           |
-| APIGEE_CLIENTTIMEOUT           | Maximum amount of time to wait for a reply from the Apigee client (default: 1m)                           |
+| Variable name             | Description                                                                                             |
+|---------------------------|---------------------------------------------------------------------------------------------------------|
+| APIGEE_AUTHFILEPATH       | The path where you put the GCP authentication file in docker container (**Ground agent only**)          |
+| APIGEE_CONTROLPLANEREGION | The physical location, specified during provisioning, at which Apigee control plane data will be stored |
+| APIGEE_PROJECTID          | The Project ID for your GCP project                                                                     |
+| APIGEE_DEVELOPEREMAIL     | The Apigee developer email                                                                              |
+| APIGEE_MODE               | Apigee agent running mode (*proxy* or *product*; default: *proxy*)                                      |
+| APIGEE_ENVIRONMENT        | The environment from which metrics are gathered                                                         |
+| APIGEE_CLIENTTIMEOUT      | Maximum amount of time to wait for a reply from the Apigee client (default: 1m)                         |
 
-If the agent requires data residency, you can prepend the control plane region to the service endpoint: `CONTROL_PLANE_LOCATION-apigee.googleapis.com`. More information regarding data residency can be found [here](https://cloud.google.com/apigee/docs/api-platform/get-started/drz-concepts#data-residency-service-endpoint).
+If the agent requires data residency, you can select a control plane region which will get prepended to the service endpoint: `CONTROL_PLANE_LOCATION-apigee.googleapis.com`. More information regarding data residency can be found [here](https://cloud.google.com/apigee/docs/api-platform/get-started/drz-concepts#data-residency-service-endpoint) and[here](https://cloud.google.com/apigee/docs/locations).
 
 ### Specific variables for Traceability Agent
 

--- a/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
@@ -32,7 +32,7 @@ All common agent variables can be found [here](/docs/connect_manage_environ/conn
 | APIGEE_ENVIRONMENT        | The environment from which metrics are gathered                                                         |
 | APIGEE_CLIENTTIMEOUT      | Maximum amount of time to wait for a reply from the Apigee client (default: 1m)                         |
 
-If the agent requires data residency, you can select a control plane region which will get prepended to the service endpoint: `CONTROL_PLANE_LOCATION-apigee.googleapis.com`. More information regarding data residency can be found [here](https://cloud.google.com/apigee/docs/api-platform/get-started/drz-concepts#data-residency-service-endpoint) and[here](https://cloud.google.com/apigee/docs/locations#available-apigee-api-control-plane-hosting-jurisdictions).
+If the agent requires data residency, you can configure variable `APIGEE_CONTROLPLANEREGION`, which will get prepended to the service endpoint: `CONTROL_PLANE_LOCATION-apigee.googleapis.com`. More information regarding data residency can be found [here](https://cloud.google.com/apigee/docs/api-platform/get-started/drz-concepts#data-residency-service-endpoint) and[here](https://cloud.google.com/apigee/docs/locations#available-apigee-api-control-plane-hosting-jurisdictions).
 
 ### Specific variables for Traceability Agent
 

--- a/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
@@ -32,7 +32,7 @@ All common agent variables can be found [here](/docs/connect_manage_environ/conn
 | APIGEE_ENVIRONMENT        | The environment from which metrics are gathered                                                         |
 | APIGEE_CLIENTTIMEOUT      | Maximum amount of time to wait for a reply from the Apigee client (default: 1m)                         |
 
-If the agent requires data residency, you can select a control plane region which will get prepended to the service endpoint: `CONTROL_PLANE_LOCATION-apigee.googleapis.com`. More information regarding data residency can be found [here](https://cloud.google.com/apigee/docs/api-platform/get-started/drz-concepts#data-residency-service-endpoint) and[here](https://cloud.google.com/apigee/docs/locations).
+If the agent requires data residency, you can select a control plane region which will get prepended to the service endpoint: `CONTROL_PLANE_LOCATION-apigee.googleapis.com`. More information regarding data residency can be found [here](https://cloud.google.com/apigee/docs/api-platform/get-started/drz-concepts#data-residency-service-endpoint) and[here](https://cloud.google.com/apigee/docs/locations#available-apigee-api-control-plane-hosting-jurisdictions).
 
 ### Specific variables for Traceability Agent
 

--- a/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
@@ -22,15 +22,15 @@ All common agent variables can be found [here](/docs/connect_manage_environ/conn
 
 ### Common variables to both agents
 
-| Variable name          | Description                                                                                               |
-|------------------------|-----------------------------------------------------------------------------------------------------------|
-| APIGEE_AUTHFILEPATH    | The path where you put the GCP authentication file in docker container (**Ground agent only**)            |
-| APIGEE_SERVICEENDPOINT | The service endpoint URL where the API services reside. Default value is `https://apigee.googleapis.com/` |
-| APIGEE_PROJECTID       | The Project ID for your GCP project                                                                       |
-| APIGEE_DEVELOPEREMAIL  | The Apigee developer email                                                                                |
-| APIGEE_MODE            | Apigee agent running mode (*proxy* or *product*; default: *proxy*)                                        |
-| APIGEE_ENVIRONMENT     | The environment from which metrics are gathered                                                           |
-| APIGEE_CLIENTTIMEOUT   | Maximum amount of time to wait for a reply from the Apigee client (default: 1m)                           |
+| Variable name                  | Description                                                                                               |
+|--------------------------------|-----------------------------------------------------------------------------------------------------------|
+| APIGEE_AUTHFILEPATH            | The path where you put the GCP authentication file in docker container (**Ground agent only**)            |
+| APIGEE_SERVICEENDPOINTLOCATION | The service endpoint URL where the API Services reside. Default value is `https://apigee.googleapis.com/` |
+| APIGEE_PROJECTID               | The Project ID for your GCP project                                                                       |
+| APIGEE_DEVELOPEREMAIL          | The Apigee developer email                                                                                |
+| APIGEE_MODE                    | Apigee agent running mode (*proxy* or *product*; default: *proxy*)                                        |
+| APIGEE_ENVIRONMENT             | The environment from which metrics are gathered                                                           |
+| APIGEE_CLIENTTIMEOUT           | Maximum amount of time to wait for a reply from the Apigee client (default: 1m)                           |
 
 If the agent requires data residency, you can prepend the control plane region to the service endpoint: `CONTROL_PLANE_LOCATION-apigee.googleapis.com`. More information regarding data residency can be found [here](https://cloud.google.com/apigee/docs/api-platform/get-started/drz-concepts#data-residency-service-endpoint).
 

--- a/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
+++ b/content/en/docs/connect_manage_environ/connect_apigee_x/agent-variables.md
@@ -25,7 +25,7 @@ All common agent variables can be found [here](/docs/connect_manage_environ/conn
 | Variable name                  | Description                                                                                               |
 |--------------------------------|-----------------------------------------------------------------------------------------------------------|
 | APIGEE_AUTHFILEPATH            | The path where you put the GCP authentication file in docker container (**Ground agent only**)            |
-| APIGEE_SERVICEENDPOINTLOCATION | The service endpoint URL where the API Services reside. Default value is `https://apigee.googleapis.com/` |
+| APIGEE_SERVICEENDPOINTLOCATION | The service endpoint URL where the API services reside. Default value is `https://apigee.googleapis.com/` |
 | APIGEE_PROJECTID               | The Project ID for your GCP project                                                                       |
 | APIGEE_DEVELOPEREMAIL          | The Apigee developer email                                                                                |
 | APIGEE_MODE                    | Apigee agent running mode (*proxy* or *product*; default: *proxy*)                                        |

--- a/content/en/docs/connect_manage_environ/connect_apigee_x/deploy-embedded-agents.md
+++ b/content/en/docs/connect_manage_environ/connect_apigee_x/deploy-embedded-agents.md
@@ -138,7 +138,6 @@ spec:
   config:
     mode: proxy
     type: Apigee
-    serviceEndpoint: https://apigee.googleapis.com/
     projectId: rd-amplify-apigee-x
     developerEmail: axway-agent@axway.com
     environment: test

--- a/content/en/docs/connect_manage_environ/connect_apigee_x/deploy-embedded-agents.md
+++ b/content/en/docs/connect_manage_environ/connect_apigee_x/deploy-embedded-agents.md
@@ -138,6 +138,7 @@ spec:
   config:
     mode: proxy
     type: Apigee
+    serviceEndpoint: https://apigee.googleapis.com/
     projectId: rd-amplify-apigee-x
     developerEmail: axway-agent@axway.com
     environment: test


### PR DESCRIPTION
Thank you for your contribution to the Amplify-Central repo.

## Describe the changes

Currently ApigeeX, service endpoint is hardcoded to apigee.googleapis.com. In this case, there is no data residency. Date residency comes into play when the agent needs to point to a certain control plane/region. This update will proactive get the location based on organization name.  But role apigee.organizations.get will need to be added

## Deploy preview link

Please add the deploy preview link to the **specific page** that you've changed.

## Checklist for contributors

Before submitting this PR:

* Verify that all status checks have passed
* For more information on the Markdown linter rules, see [DavidAnson/markdownlint](https://github.com/DavidAnson/markdownlint)
* For first-time contributors, ensure that you have signed the [Axway CLA](https://cla.axway.com/)
