### PR TITLE
APIGOV-32272 - Update public docs to remove weak ECDHE-ECDSA CBC cipher suites

### DIFF
--- a/content/en/docs/connect_manage_environ/connected_agent_common_reference/agent_security.md
+++ b/content/en/docs/connect_manage_environ/connected_agent_common_reference/agent_security.md
@@ -24,19 +24,9 @@ TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 
 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 
-TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-
-TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-
 The full list of cipher suites is extensive, and many may not be supported by the various servers. The cipher suites listed above are generally considered to be the most secure. Here is a full list of cipher suites that the agents allow for configuration:
 
-TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-
-TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-
 TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-
-TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
 
 TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
 


### PR DESCRIPTION
Updates the Administer agent security documentation to remove weak CBC-mode cipher suites that are no longer supported by the Agent SDK.

Target release date to Pre-prod is April 2nd 2026
