### PR TITLE
APIGOV-32898 AgentCore documentation

### DIFF
--- a/content/en/docs/connect_manage_environ/connect_aws_gateway/_index.md
+++ b/content/en/docs/connect_manage_environ/connect_aws_gateway/_index.md
@@ -1,14 +1,14 @@
 ---
-title: Connect AWS Gateway
-linkTitle: Connect AWS Gateway
+title: Connect AWS Gateways
+linkTitle: Connect AWS Gateways
 weight: 130
 date: 2021-01-04
 ---
-Connect AWS API Gateway and Amplify so you can govern and monitor the creation / deployment / publishing and subscriptions of the AWS API Gateway hosted APIs in one central location.
+Connect AWS API Gateway or AWS Bedrock AgentCore Gateway and Amplify so you can govern and monitor the creation / deployment / publishing and subscriptions of your AWS hosted APIs in one central location.
 
 {{< alert title="Note" color="primary" >}}Go [here](/docs/connect_manage_environ/connect_aws_gateway/deploy-embedded-agents/) for documentation on installing the AWS Embedded agents.{{< /alert >}}
 
-## Why do you want to connect AWS API Gateway and Amplify?
+## AWS API Gateway mode
 
 Connecting AWS API Gateway to Amplify will provide you with a global centralized view of your APIs and their related traffic.
 
@@ -36,6 +36,21 @@ The types of logging you can do with API Gateway to CloudWatch:
 
 For additional logging information, see <https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html>.
 
+## AWS Bedrock AgentCore Gateway mode
+
+Connecting AWS Bedrock AgentCore Gateway to Amplify allows you to discover and govern APIs hosted behind AgentCore gateways and manage consumer credentials through Cognito.
+
+Each AgentCore Gateway can be represented by an Amplify environment. The Discovery Agent interacts with the Bedrock AgentCore control plane and Amplify to:
+
+* Detect AgentCore gateways in `READY` status and publish them to Amplify as API services with auto-generated OpenAPI 3.0 and MCP specifications. The gateway's authorizer type determines which Credential Request Definition (CRD) is assigned to the published service.
+* Manage Cognito app clients on behalf of consumers when they subscribe to or unsubscribe from a discovered API service.
+
+{{< alert title="Note" color="primary" >}}Traceability Agent is not yet available for AgentCore Gateway mode.{{< /alert >}}
+
+### Discovery Agent
+
+The Discovery Agent polls the Bedrock AgentCore control plane for gateways and their authorizer configuration. It regularly checks for new or updated gateways and pushes the corresponding API service definitions to Amplify.
+
 ## Prerequisites
 
 * An Axway Amplify subscription in the Amplify platform
@@ -45,6 +60,12 @@ For additional logging information, see <https://docs.aws.amazon.com/apigateway/
 * Amazon CloudWatch Service
 * CloudFormation template. Download the latest "Amplify AWS Agents CloudFormation" install zip file from [https://repository.axway.com/catalog?q=aws](https://repository.axway.com/catalog?q=aws).
 * The [Traceability Agent](#traceability-agent) requires a connected and running [Discovery Agent](#discovery-agent)
+
+For AgentCore Gateway mode, the following additional prerequisites apply:
+
+* AWS Bedrock AgentCore gateway(s) deployed in your AWS account
+* A Cognito User Pool configured as the JWT authorizer on the gateway (for gateways using CUSTOM_JWT authorization)
+* An IAM policy with `bedrock-agentcore`, `cognito-idp`, and `iam:PassRole` permissions attached to the agent's IAM role or user. See [AWS IAM policy for AgentCore mode](/docs/connect_manage_environ/connect_aws_gateway/embedded-aws-agent-setup/#aws-iam-policy-for-agentcore-mode).
 
 ## Region support
 

--- a/content/en/docs/connect_manage_environ/connect_aws_gateway/_index.md
+++ b/content/en/docs/connect_manage_environ/connect_aws_gateway/_index.md
@@ -4,7 +4,7 @@ linkTitle: Connect AWS Gateways
 weight: 130
 date: 2021-01-04
 ---
-Connect AWS API Gateway or AWS Bedrock AgentCore Gateway and Amplify so you can govern and monitor the creation / deployment / publishing and subscriptions of your AWS hosted APIs in one central location.
+Connect AWS API Gateway / AWS Bedrock AgentCore and Amplify so you can govern and monitor the creation / deployment / publishing and subscriptions of your AWS hosted APIs in one central location.
 
 {{< alert title="Note" color="primary" >}}Go [here](/docs/connect_manage_environ/connect_aws_gateway/deploy-embedded-agents/) for documentation on installing the AWS Embedded agents.{{< /alert >}}
 
@@ -36,16 +36,16 @@ The types of logging you can do with API Gateway to CloudWatch:
 
 For additional logging information, see <https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html>.
 
-## AWS Bedrock AgentCore Gateway mode
+## AWS Bedrock AgentCore mode
 
-Connecting AWS Bedrock AgentCore Gateway to Amplify allows you to discover and govern APIs hosted behind AgentCore gateways and manage consumer credentials through Cognito.
+Connecting AWS Bedrock AgentCore to Amplify allows you to discover and govern APIs hosted behind AgentCore gateways and manage consumer credentials through Cognito.
 
-Each AgentCore Gateway can be represented by an Amplify environment. The Discovery Agent interacts with the Bedrock AgentCore control plane and Amplify to:
+The Bedrock AgentCore control plane can be represented by an Amplify environment, and each AgentCore gateway discovered within it is published as an API service. The Discovery Agent interacts with the Bedrock AgentCore control plane and Amplify to:
 
 * Detect AgentCore gateways in `READY` status and publish them to Amplify as API services with auto-generated OpenAPI 3.0 and MCP specifications. The gateway's authorizer type determines which Credential Request Definition (CRD) is assigned to the published service.
 * Manage Cognito app clients on behalf of consumers when they subscribe to or unsubscribe from a discovered API service.
 
-{{< alert title="Note" color="primary" >}}Traceability Agent is not yet available for AgentCore Gateway mode.{{< /alert >}}
+{{< alert title="Note" color="primary" >}}Traceability Agent is not yet available for AgentCore mode.{{< /alert >}}
 
 ### Discovery Agent (AgentCore)
 
@@ -61,7 +61,7 @@ The Discovery Agent polls the Bedrock AgentCore control plane for gateways and t
 * CloudFormation template. Download the latest "Amplify AWS Agents CloudFormation" install zip file from [https://repository.axway.com/catalog?q=aws](https://repository.axway.com/catalog?q=aws).
 * The [Traceability Agent](#traceability-agent) requires a connected and running [Discovery Agent](#discovery-agent)
 
-For AgentCore Gateway mode, the following additional prerequisites apply:
+For AgentCore mode, the following additional prerequisites apply:
 
 * AWS Bedrock AgentCore gateway(s) deployed in your AWS account
 * A Cognito User Pool configured as the JWT authorizer on the gateway (for gateways using CUSTOM_JWT authorization)

--- a/content/en/docs/connect_manage_environ/connect_aws_gateway/_index.md
+++ b/content/en/docs/connect_manage_environ/connect_aws_gateway/_index.md
@@ -47,7 +47,7 @@ Each AgentCore Gateway can be represented by an Amplify environment. The Discove
 
 {{< alert title="Note" color="primary" >}}Traceability Agent is not yet available for AgentCore Gateway mode.{{< /alert >}}
 
-### Discovery Agent
+### Discovery Agent (AgentCore)
 
 The Discovery Agent polls the Bedrock AgentCore control plane for gateways and their authorizer configuration. It regularly checks for new or updated gateways and pushes the corresponding API service definitions to Amplify.
 

--- a/content/en/docs/connect_manage_environ/connect_aws_gateway/credential-provisioning-agentcore.md
+++ b/content/en/docs/connect_manage_environ/connect_aws_gateway/credential-provisioning-agentcore.md
@@ -1,0 +1,48 @@
+---
+title: Credential provisioning for AgentCore gateways
+linkTitle: Credential provisioning - AgentCore
+draft: false
+weight: 55
+---
+When a consumer subscribes to an API service discovered from an AgentCore gateway, the Provisioning Agent automatically creates and manages credentials in the authorizer service linked to that gateway. The type of credentials depends on the gateway's authorizer configuration.
+
+## Before you start
+
+* AgentCore mode must be configured. See [AgentCore Gateway mode configuration](/docs/connect_manage_environ/connect_aws_gateway/deploy-your-agents-1/#agentcore-gateway-mode-configuration).
+* For gateways using CUSTOM_JWT authorization, at least one Cognito User Pool must be configured via `AWS_COGNITO_USERPOOLID_N` and `AWS_COGNITO_REGION_N`.
+* The agent's IAM policy must include the [Provisioning permissions](/docs/connect_manage_environ/connect_aws_gateway/embedded-aws-agent-setup/#provisioning-policy).
+
+## Objectives
+
+Learn about the available Credential Request Definitions (CRDs) for AgentCore gateways and how credentials are created and removed for Cognito-secured and IAM-secured gateways.
+
+## Available credential request definitions
+
+The agent assigns a Credential Request Definition (CRD) to each discovered API service based on the gateway's authorizer type:
+
+| Gateway authorizer | CRD name | Notes |
+| --- | --- | --- |
+| `CUSTOM_JWT` (Cognito issuer) | `cognito-{user-pool-id}` | Assigned when the issuer URL matches a configured Cognito User Pool. The pool ID is normalized to lowercase with underscores replaced by hyphens. For example, pool `eu-west-1_cEL0M3519` produces CRD name `cognito-eu-west-1-cel0m3519`. |
+| `AWS_IAM` | `aws-iam` | Assigned only when `AWS_AGENTCORE_IAMAUTHENABLED=true`. The gateway is still discovered and published without a CRD when this flag is `false`. |
+| `NONE` | *(none)* | No credentials are required; no CRD is assigned. |
+
+## Cognito credential lifecycle
+
+### On subscription
+
+The Provisioning Agent creates a new app client in the configured Cognito User Pool. The returned `client_id` and `client_secret` are delivered to the consumer. The client ID is also added to the gateway's `allowedClients` list via `bedrock-agentcore:UpdateGateway`.
+
+### On unsubscription
+
+The Provisioning Agent deletes the app client from the Cognito User Pool and removes the client ID from the gateway's `allowedClients` list.
+
+## IAM credential handling
+
+Gateways with `AWS_IAM` authorizer are always discovered and published to Amplify. When `AWS_AGENTCORE_IAMAUTHENABLED=true`, the published service is associated with the `aws-iam` CRD, allowing consumers to request credentials through Amplify. When the flag is `false`, the gateway is published without a CRD — it is visible in Amplify but no managed credential flow is available.
+
+No external credential resources are created in either case. Consumers authenticate using their own AWS credentials with the appropriate IAM permissions to invoke the gateway.
+
+## Related topics
+
+* [AWS IAM policy for AgentCore mode](/docs/connect_manage_environ/connect_aws_gateway/embedded-aws-agent-setup/#aws-iam-policy-for-agentcore-mode)
+* [AgentCore Gateway mode configuration](/docs/connect_manage_environ/connect_aws_gateway/deploy-your-agents-1/#agentcore-gateway-mode-configuration)

--- a/content/en/docs/connect_manage_environ/connect_aws_gateway/deploy-your-agents-1.md
+++ b/content/en/docs/connect_manage_environ/connect_aws_gateway/deploy-your-agents-1.md
@@ -41,6 +41,21 @@ All common agent variables can be found [here](/docs/connect_manage_environ/conn
 | AWS_PUSHTAGS                         | Determines whether the AWS Stage tags should be pushed to Amplify along with the API definition. Value must be true or false. Default is false.                                                                                                                                                                                                                                                                                                                                    |
 | AWS_REGION                           | The region where AWS APIs are stored.                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 
+### AgentCore Gateway mode configuration
+
+The following variables are specific to `agentcore-gateway` mode. Set `AWS_GATEWAYMODE` to enable AgentCore mode; the remaining variables are only relevant when AgentCore mode is active.
+
+| Variable name | Description |
+| --- | --- |
+| AWS_GATEWAYMODE | The AWS backend the agent connects to. Set to `agentcore-gateway` to enable Bedrock AgentCore mode. Default is `api-gateway`. |
+| AWS_AGENTCORE_PAGESIZE | Page size for `ListGateways` and `ListGatewayTargets` API requests (on-premises Discovery Agent only). Default is `25`. |
+| AWS_AGENTCORE_LOGGROUPPREFIX | CloudWatch log group prefix for AgentCore gateway application logs. Default is `/aws/vendedlogs/bedrock-agentcore/gateway/APPLICATION_LOGS`. |
+| AWS_AGENTCORE_IAMAUTHENABLED | When set to `true`, gateways using `AWS_IAM` authorization are discovered and associated with the `aws-iam` credential request definition. The gateway is still discovered and published without a credential request definition when this flag is `false`. Default is `false`. |
+| AWS_COGNITO_USERPOOLID_N | Cognito User Pool ID for the Nth pool, where N starts at 1 (for example, `AWS_COGNITO_USERPOOLID_1=eu-west-1_abc123`). Used to match CUSTOM_JWT gateway issuers to a specific Cognito pool for credential provisioning. |
+| AWS_COGNITO_REGION_N | AWS region for the Nth Cognito pool (for example, `AWS_COGNITO_REGION_1=eu-west-1`). Optional; falls back to `AWS_REGION` if not set. |
+
+{{< alert title="Note" color="primary" >}}Multiple Cognito pools are supported by incrementing the index (`_1`, `_2`, and so on).{{< /alert >}}
+
 ### Create your Discovery Agent environment file
 
 Create a configuration file using the above variables. See the variable descriptions for their values. Below is a sample of what the configuration file will look like.
@@ -73,6 +88,38 @@ LOG_LEVEL=info
 LOG_OUTPUT=stdout
 LOG_PATH=logs
 ```
+
+For AgentCore Gateway mode:
+
+```yaml
+# AWS connectivity - AgentCore mode
+AWS_REGION=eu-west-1
+AWS_AUTH_ACCESSKEY=<YOUR AWS ACCESS KEY HERE>
+AWS_AUTH_SECRETKEY=<YOUR AWS SECRET KEY HERE>
+AWS_GATEWAYMODE=agentcore-gateway
+AWS_AGENTCORE_PAGESIZE=25
+AWS_COGNITO_USERPOOLID_1=<YOUR COGNITO USER POOL ID>
+AWS_COGNITO_REGION_1=eu-west-1
+
+# Amplify connectivity
+# organization config:
+CENTRAL_ORGANIZATIONID=<YOUR ORGANIZATION ID>
+CENTRAL_TEAM=<THE TEAM NAME>
+CENTRAL_ENVIRONMENT=<NAME OF THE CENTRAL TOPOLOGY ENVIRONMENT>
+CENTRAL_AUTH_CLIENTID=<SERVICE ACCOUNT NAME>
+
+#CENTRAL_SSL_MINVERSION=
+#CENTRAL_SSL_MAXVERSION=
+#CENTRAL_SSL_CIPHERSUITES=
+#CENTRAL_SSL_NEXTPROTOS=
+#CENTRAL_SSL_INSECURESKIPVERIFY=
+
+LOG_LEVEL=info
+LOG_OUTPUT=stdout
+LOG_PATH=logs
+```
+
+{{< alert title="Note" color="primary" >}}Traceability Agent is not yet supported in AgentCore mode. No Traceability Agent configuration is required when using `agentcore-gateway`.{{< /alert >}}
 
 ### Install and run Discovery Agent
 

--- a/content/en/docs/connect_manage_environ/connect_aws_gateway/embedded-aws-agent-setup.md
+++ b/content/en/docs/connect_manage_environ/connect_aws_gateway/embedded-aws-agent-setup.md
@@ -239,3 +239,82 @@ Create an IAM user and generate an Access Key ID and Secret Access Key ID that t
 9. Select **Third-party service** and acknowledge that you understand the risks before clicking **Next**.
 10. Give an optional description and click **Create access key**.
 11. Note the Access Key ID and the Secret Access Key to be used during installation.
+
+## AWS IAM policy for AgentCore mode
+
+Create an IAM policy that allows the agent to discover and provision access to your AWS Bedrock AgentCore gateway resources. This policy is required when running in `agentcore-gateway` mode. Attach it to the same IAM role or user used by the agents.
+
+1. Within the AWS IAM Console, start the *Create policy* wizard.
+2. Select the *JSON editor* tab and paste the [Discovery policy JSON](#discovery-policy) below. If provisioning is also enabled, the provisioning permissions can be added to the same policy — a separate policy is not required.
+3. Update the placeholder values:
+   * `<aws-region>` becomes your AWS region, such as `eu-west-1`
+   * `<aws-account-id>` becomes your AWS account ID
+   * `<user-pool-id>` becomes your Cognito User Pool ID (Provisioning permissions only)
+4. Click **Next: Tags** and add any tags you may want.
+5. Click **Next: Review**.
+6. Give the policy a name, such as `AmplifyAgentCorePolicy`.
+
+### Discovery policy
+
+Required for the Discovery Agent to list and inspect AgentCore gateways:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "bedrock-agentcore:ListGateways",
+                "bedrock-agentcore:GetGateway",
+                "bedrock-agentcore:ListGatewayTargets",
+                "bedrock-agentcore:GetGatewayTarget"
+            ],
+            "Resource": "arn:aws:bedrock-agentcore:<aws-region>:<aws-account-id>:gateway/*"
+        }
+    ]
+}
+```
+
+### Provisioning policy
+
+Required for the Provisioning Agent to manage Cognito app clients and update the gateway's allowed-client list on subscribe and unsubscribe events. These statements can be added to the existing AgentCore discovery policy — no separate policy file is needed:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "bedrock-agentcore:UpdateGateway"
+            ],
+            "Resource": "arn:aws:bedrock-agentcore:<aws-region>:<aws-account-id>:gateway/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cognito-idp:ListUserPoolClients",
+                "cognito-idp:CreateUserPoolClient",
+                "cognito-idp:DescribeUserPoolClient",
+                "cognito-idp:UpdateUserPoolClient",
+                "cognito-idp:DeleteUserPoolClient"
+            ],
+            "Resource": "arn:aws:cognito-idp:<aws-region>:<aws-account-id>:userpool/<user-pool-id>"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "iam:PassRole",
+            "Resource": "arn:aws:iam::<aws-account-id>:role/*"
+        }
+    ]
+}
+```
+
+| Permission | Purpose |
+| --- | --- |
+| `bedrock-agentcore:UpdateGateway` | Provisioning Agent updates the gateway's `allowedClients` list when credentials are issued or revoked |
+| `cognito-idp:*` | Provisioning Agent creates, describes, updates, and deletes app clients in the Cognito User Pool linked to the gateway's CUSTOM_JWT authorizer |
+| `iam:PassRole` | Required so Bedrock AgentCore can assume the execution role associated with the gateway when processing provisioning updates |
+
+{{< alert title="Note" color="primary" >}}The `iam:PassRole` resource can be scoped to a specific role ARN instead of a wildcard for least-privilege configurations.{{< /alert >}}


### PR DESCRIPTION
AWS AgentCore documentation draft

This doc has to wait for publishing until at least June 25th 2026 when this becomes available in production.  Provisioning will likely come 2 weeks after that so we have to think about how we publish that portion of the docs.
